### PR TITLE
Fix: Improve dark theme visibility for actions and elements

### DIFF
--- a/client/src/components/draggable-action.tsx
+++ b/client/src/components/draggable-action.tsx
@@ -80,12 +80,12 @@ export function DraggableAction({ action, stepId, onDropElement, targetElement }
         <div className="flex items-center space-x-3">
           {renderActionIcon(action.icon)}
           <div>
-            <div className="font-medium text-gray-900 text-sm">{action.name}</div>
-            <div className="text-xs text-gray-500">{action.description}</div>
+            <div className="font-medium text-foreground text-sm">{action.name}</div>
+            <div className="text-xs text-muted-foreground">{action.description}</div>
             {/* Display info about the target element if it exists */}
             {targetElement && (
               <div className="mt-1 pt-1 border-t border-gray-200">
-                <p className="text-xs text-blue-600 truncate" title={targetElement.selector}>
+                <p className="text-xs text-primary truncate" title={targetElement.selector}>
                   Target: {targetElement.text || targetElement.selector}
                 </p>
               </div>

--- a/client/src/components/draggable-element.tsx
+++ b/client/src/components/draggable-element.tsx
@@ -33,7 +33,7 @@ export function DraggableElement({ element, onHover }: DraggableElementProps) {
   }));
 
   const renderElementIcon = (type: string) => {
-    const iconProps = { className: "h-4 w-4 text-gray-500" };
+    const iconProps = { className: "h-4 w-4 text-muted-foreground" };
     switch (type) {
       case "input":
       case "text":
@@ -44,7 +44,7 @@ export function DraggableElement({ element, onHover }: DraggableElementProps) {
       case "link":
         return <MousePointer {...iconProps} />;
       case "heading":
-        return <span className="text-gray-500 font-bold text-sm">H</span>;
+        return <span className="text-muted-foreground font-bold text-sm">H</span>;
       default:
         return <MousePointer {...iconProps} />;
     }
@@ -57,17 +57,17 @@ export function DraggableElement({ element, onHover }: DraggableElementProps) {
       case "password":
       case "email":
       case "textarea":
-        return "bg-blue-100 text-blue-800";
+        return "bg-primary text-primary-foreground";
       case "button":
-        return "bg-green-100 text-green-800";
+        return "bg-success text-primary-foreground";
       case "link":
-        return "bg-purple-100 text-purple-800";
+        return "bg-accent text-accent-foreground";
       case "heading":
-        return "bg-gray-100 text-gray-800";
+        return "bg-secondary text-secondary-foreground";
       case "select":
-        return "bg-yellow-100 text-yellow-800";
+        return "bg-secondary text-secondary-foreground";
       default:
-        return "bg-gray-100 text-gray-800";
+        return "bg-secondary text-secondary-foreground";
     }
   };
 
@@ -87,12 +87,12 @@ export function DraggableElement({ element, onHover }: DraggableElementProps) {
             <Badge variant="secondary" className={`text-xs ${getTypeColor(element.type)}`}>
               {element.type}
             </Badge>
-            <span className="text-xs text-gray-400">{element.tag}</span>
+            <span className="text-xs text-muted-foreground">{element.tag}</span>
           </div>
-          <div className="font-medium text-gray-900 text-sm truncate">
+          <div className="font-medium text-foreground text-sm truncate">
             {element.text || element.attributes.placeholder || element.attributes.alt || `${element.tag} element`}
           </div>
-          <div className="text-xs text-gray-500 truncate">
+          <div className="text-xs text-muted-foreground truncate">
             {element.selector}
           </div>
         </div>


### PR DESCRIPTION
Previously, several text and background colors in DraggableAction and DraggableElement components were hardcoded, leading to poor contrast and readability issues in dark mode.

This commit updates these components to use theme-aware Tailwind CSS utility classes that derive their colors from CSS variables defined in index.css.

Specifically:
- Updated DraggableAction to use --foreground, --muted-foreground, and --primary for text elements.
- Updated DraggableElement to use --foreground and --muted-foreground for text elements.
- Modified the getTypeColor function in DraggableElement to use combinations like --primary/--primary-foreground, --success/--primary-foreground, --accent/--accent-foreground, and --secondary/--secondary-foreground for badges, ensuring they adapt to the current theme.

These changes significantly improve the visibility of labels and detected elements when the dark theme is active, and also ensure that light mode remains correct.