### PR TITLE
Refactor: Replace test name input with modal on save

### DIFF
--- a/client/src/components/SaveTestModal.tsx
+++ b/client/src/components/SaveTestModal.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'; // Assuming this is the correct path for ShadCN Dialog
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface SaveTestModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (testName: string) => void;
+  initialTestName?: string;
+}
+
+const SaveTestModal: React.FC<SaveTestModalProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+  initialTestName,
+}) => {
+  const [internalTestName, setInternalTestName] = useState(initialTestName || '');
+
+  useEffect(() => {
+    if (isOpen) {
+      setInternalTestName(initialTestName || '');
+    }
+  }, [isOpen, initialTestName]);
+
+  const handleSave = () => {
+    if (internalTestName.trim()) {
+      onSave(internalTestName.trim());
+    }
+  };
+
+  const isSaveDisabled = internalTestName.trim() === '';
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Save Test</DialogTitle>
+          <DialogDescription>
+            Please enter a name for your test. This will help you identify it later.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="testName" className="text-right">
+              Test Name
+            </Label>
+            <Input
+              id="testName"
+              value={internalTestName}
+              onChange={(e) => setInternalTestName(e.target.value)}
+              className="col-span-3"
+              placeholder="e.g., Login Functionality Test"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={isSaveDisabled}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SaveTestModal;

--- a/client/src/pages/dashboard-page-new.tsx
+++ b/client/src/pages/dashboard-page-new.tsx
@@ -19,6 +19,7 @@ import { DraggableAction } from "@/components/draggable-action";
 import { DraggableElement } from "@/components/draggable-element";
 import { TestSequenceBuilder } from "@/components/test-sequence-builder";
 import { TestStep as DragDropTestStep } from "@/components/drag-drop-provider";
+import SaveTestModal from "@/components/SaveTestModal"; // Import the modal
 import { 
   TestTube,
   Globe,
@@ -216,6 +217,7 @@ export default function DashboardPage() {
   const [playbackSteps, setPlaybackSteps] = useState<StepResult[]>([]);
   const [currentSavedTestId, setCurrentSavedTestId] = useState<string | null>(null); // To store ID of saved/loaded test
   const [testName, setTestName] = useState<string>(""); // To store test name
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
 
 
   const imageRef = useRef<HTMLImageElement>(null);
@@ -474,7 +476,28 @@ export default function DashboardPage() {
       });
       return;
     }
-    saveTestMutation.mutate();
+    // saveTestMutation.mutate(); // This will be moved to the modal
+    handleOpenSaveModal();
+  };
+
+  const handleOpenSaveModal = () => {
+    setIsSaveModalOpen(true);
+  };
+
+  const handleCloseSaveModal = () => {
+    setIsSaveModalOpen(false);
+  };
+
+  const handleConfirmSaveTest = (newName: string) => {
+    setTestName(newName); // Update the main page's testName state
+    saveTestMutation.mutate({
+      name: newName,
+      url: currentUrl,
+      sequence: testSequence,
+      elements: detectedElements,
+      status: "draft", // Or any default status
+    });
+    handleCloseSaveModal(); // Close the modal after saving
   };
 
   const startRecordingMutation = useMutation({
@@ -1012,15 +1035,6 @@ export default function DashboardPage() {
       <div className="bg-card border-b border-border px-6 py-4">
         <div className="flex items-center space-x-4">
           <div className="flex-grow">
-            <Label htmlFor="testNameInput" className="block text-sm font-medium text-card-foreground mb-1">Test Name</Label>
-            <Input
-              id="testNameInput"
-              type="text"
-              placeholder="Enter test name (e.g., Login Flow)"
-              value={testName}
-              onChange={(e) => setTestName(e.target.value)}
-              className="mb-3"
-            />
             <Label htmlFor="urlInput" className="block text-sm font-medium text-card-foreground mb-1">Website URL to Test</Label>
             <div className="flex space-x-3">
               <Input
@@ -1253,6 +1267,12 @@ export default function DashboardPage() {
           />
         </div>
       </div>
+      <SaveTestModal
+        isOpen={isSaveModalOpen}
+        onClose={handleCloseSaveModal}
+        onSave={handleConfirmSaveTest}
+        initialTestName={testName}
+      />
     </div>
   );
 }


### PR DESCRIPTION
I've replaced the direct text input field for the test name on the 'Create Test' page with a modal dialog.

Key changes:
- I removed the `Input` field for `testName` from `dashboard-page-new.tsx`.
- I created a new `SaveTestModal.tsx` component that includes an input field for the test name, along with 'Save' and 'Cancel' actions.
- I modified the 'Save Test' button functionality:
    - Clicking 'Save Test' now opens the `SaveTestModal`.
    - The test name is entered within the modal.
    - Saving from the modal triggers the test save operation with the provided name.
- I ensured that the existing `testName` state and save mutation logic in `dashboard-page-new.tsx` are correctly utilized by the new modal flow.

This change improves the user experience by streamlining the initial view of the 'Create Test' page and providing a focused dialog for test naming during the save process.