### PR TITLE
feat: Implement clear test result display

### DIFF
--- a/client/src/components/test-sequence-builder.tsx
+++ b/client/src/components/test-sequence-builder.tsx
@@ -18,7 +18,7 @@ import {
 import { availableActions, TestAction } from "@/pages/dashboard-page-new";
 import { TestStep, DetectedElement } from "@/components/drag-drop-provider"; // TestAction removed from here
 import { DraggableAction } from "./draggable-action"; // Import DraggableAction
-import { Trash2, Settings, Plus, Link2, RefreshCw } from "lucide-react"; // Added Link2 for element icon, RefreshCw as an option
+import { Trash2, Settings, Plus, Link2, RefreshCw, CheckCircle2, XCircle } from "lucide-react"; // Added Link2 for element icon, RefreshCw as an option
 // Icons for actions are now rendered by DraggableAction, so they might not be needed here directly
 // unless used for other UI elements. Keeping them for now.
 // Specific action icons (MousePointer, Keyboard, etc.) might not be needed if DraggableAction handles icon display
@@ -43,6 +43,7 @@ interface TestSequenceBuilderProps {
   isExecuting?: boolean;
   isSaving?: boolean;
   isRecordingActive?: boolean; // New prop
+  lastTestOutcome?: boolean | null; // New prop for test outcome
 }
 
 export function TestSequenceBuilder({
@@ -54,6 +55,7 @@ export function TestSequenceBuilder({
   isExecuting = false,
   isSaving = false,
   isRecordingActive = false, // Default value for the new prop
+  lastTestOutcome = null, // Default value for the new prop
 }: TestSequenceBuilderProps) {
   const [isReassociatingElementForStepId, setReassociatingElementForStepId] = useState<string | null>(null);
 
@@ -311,7 +313,13 @@ export function TestSequenceBuilder({
 
       {/* Action Buttons */}
       <Separator className="my-4" /> {/* Separator component from ui/ is theme-aware */}
-      <div className="flex space-x-3">
+      <div className="flex items-center space-x-3"> {/* Added items-center for vertical alignment */}
+        {lastTestOutcome === true && (
+          <CheckCircle2 className="mr-2 h-5 w-5 text-green-500" />
+        )}
+        {lastTestOutcome === false && (
+          <XCircle className="mr-2 h-5 w-5 text-red-500" />
+        )}
         <Button
           onClick={onExecuteTest}
           disabled={testSequence.length === 0 || isExecuting}


### PR DESCRIPTION
This commit introduces several enhancements to make test execution results (Pass/Fail) clearly visible to you.

Key changes:

- Modified the `executeDirectTestMutation` in `DashboardPage`:
  - On successful test execution and after step playback, a toast notification now explicitly states "Test Passed" or "Test Failed" based on the overall result from the backend.
  - If the test execution request fails or the backend indicates an immediate failure (before playback), a "Test Failed" toast is shown.
  - The `lastTestOverallResult` state is used to track and propagate this overall outcome.

- Updated `TestSequenceBuilder`:
  - It now receives the `lastTestOverallResult` as a prop.
  - Displays a persistent icon (green check for pass, red X for fail) next to the "Execute Test" button, indicating the outcome of the most recent test.

- Added a dedicated UI section in `DashboardPage`:
  - This new section, located below the URL input, prominently displays "Test Result: Passed" or "Test Result: Failed" with corresponding icons.
  - This UI element updates after each test run.

- State Reset Logic:
  - Ensured that `lastTestOverallResult` (and consequently the new UI displays) is reset appropriately when a new test is initiated, the URL is changed, or the test sequence is cleared.

These changes provide you with immediate and persistent feedback on test outcomes, improving your overall user experience of the test creation and execution process.