### PR TITLE
Refactor: Standardize page headers for consistent navigation

### DIFF
--- a/client/src/pages/dashboard-page-new.tsx
+++ b/client/src/pages/dashboard-page-new.tsx
@@ -1010,8 +1010,11 @@ export default function DashboardPage() {
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-4">
             <div className="flex items-center space-x-2">
+              <Link href="/dashboard" className="flex items-center space-x-2 text-primary hover:underline">
+                <ArrowLeft className="h-5 w-5" />
+              </Link>
               <TestTube className="h-6 w-6 text-primary" />
-              <h1 className="text-xl font-bold text-card-foreground">WebTest Platform</h1>
+              <h1 className="text-xl font-bold text-card-foreground">Create Web Test</h1>
             </div>
             
           </div>
@@ -1040,18 +1043,6 @@ export default function DashboardPage() {
           </div>
         </div>
       </header>
-
-      {/* Back to Dashboard Button Section */}
-      <div className="px-6 pt-4 bg-card border-b border-border">
-        <div className="mb-4">
-          <Link href="/dashboard">
-            <Button variant="outline" size="sm">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back To Dashboard
-            </Button>
-          </Link>
-        </div>
-      </div>
 
       {/* URL Input Section */}
       <div className="bg-card border-b border-border px-6 py-4">

--- a/client/src/pages/dashboard-page.tsx
+++ b/client/src/pages/dashboard-page.tsx
@@ -212,9 +212,12 @@ export default function DashboardPage() {
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-4">
             <div className="flex items-center space-x-2">
+              <Link href="/dashboard" className="flex items-center space-x-2 text-primary hover:underline">
+                <ArrowLeft className="h-5 w-5" />
+              </Link>
               <TestTube className="h-6 w-6 text-primary" />
               {/* Title as per prompt, not using t() here based on instruction for "exact JSX" */}
-              <h1 className="text-xl font-bold text-gray-900">Web Automation Platform</h1>
+              <h1 className="text-xl font-bold text-gray-900">Create Web Test</h1>
             </div>
           </div>
           <div className="flex items-center space-x-4">
@@ -241,18 +244,6 @@ export default function DashboardPage() {
           </div>
         </div>
       </header>
-
-      {/* Back to Dashboard Button Section */}
-      <div className="px-6 pt-4 bg-white border-b border-gray-200">
-        <div className="mb-4">
-          <Link href="/dashboard">
-            <Button variant="outline" size="sm">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              {t('nav.backToDashboard')}
-            </Button>
-          </Link>
-        </div>
-      </div>
 
       {/* URL Input Section */}
       <div className="bg-white border-b border-gray-200 px-6 py-4">

--- a/client/src/pages/settings-page.tsx
+++ b/client/src/pages/settings-page.tsx
@@ -295,18 +295,12 @@ export default function SettingsPage() {
       {/* Header */}
       <header className="bg-card border-b border-border px-6 py-4"> {/* Apply dark mode classes */}
         <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-4">
-            <Link href="/dashboard"> {/* Changed href to /dashboard */}
-              <Button variant="ghost" size="sm">
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                {t('nav.backToDashboard')} {/* Used translation key */}
-              </Button>
+          <div className="flex items-center space-x-2">
+            <Link href="/dashboard" className="flex items-center space-x-2 text-primary hover:underline">
+                <ArrowLeft className="h-5 w-5" />
             </Link>
-            
-            <div className="flex items-center space-x-2">
-              <Settings className="h-6 w-6 text-primary" />
-              <h1 className="text-xl font-bold">Settings</h1> {/* Apply dark mode classes */}
-            </div>
+            <Settings className="h-6 w-6 text-primary" />
+            <h1 className="text-xl font-bold text-card-foreground">Settings</h1> {/* Apply dark mode classes */}
           </div>
           
           <div className="flex items-center space-x-4">


### PR DESCRIPTION
This commit updates the header structure across multiple pages to ensure a consistent user experience:

- The back arrow icon (leading to the Dashboard) is now consistently placed next to the page title in the header.
- Page titles in the header now accurately reflect the current page (e.g., "Create Web Test", "Settings") instead of generic titles.
- Redundant "Back to Dashboard" buttons within page content have been removed in favor of the standardized header navigation.

Affected pages:
- client/src/pages/dashboard-page-new.tsx
- client/src/pages/settings-page.tsx
- client/src/pages/dashboard-page.tsx

The `ApiTesterPage.tsx` was used as the reference for the new header style. `DashboardOverviewPage.tsx` was not modified as it uses a different sidebar-based navigation pattern.