### PR TITLE
Fix: Import TestTube icon in dashboard page

### DIFF
--- a/client/src/pages/dashboard-page-new.tsx
+++ b/client/src/pages/dashboard-page-new.tsx
@@ -34,6 +34,7 @@ import {
   ArrowLeft, // Add this if not present
   XCircle, // Added for test result display
   PlusSquare, // Added for page icon
+  TestTube, // Added this icon
 } from "lucide-react";
 import { Link } from "wouter";
 import debounceFromLodash from 'lodash/debounce'; // Attempt to import lodash.debounce


### PR DESCRIPTION
The TestTube icon was being used in `dashboard-page-new.tsx` without being imported from `lucide-react`, causing a runtime error.

This commit adds `TestTube` to the list of imported icons from `lucide-react` to resolve the 'TestTube is not defined' error.