### PR TITLE
⚡ Bolt: [performance improvement] Optimize DraggableElement with React.memo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Optimizing large lists in React with React.memo
+**Learning:** Re-rendering a large list of stable items (like the detected elements on DashboardPage) when a non-related parent state changes (like hovering to set `highlightedElement`) can cause significant performance bottlenecks in React.
+**Action:** Always wrap list item components in `React.memo` if they depend on stable props but their parent re-renders frequently, to prevent unnecessary reconciliations.

--- a/client/src/components/draggable-element.tsx
+++ b/client/src/components/draggable-element.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { useDrag } from "react-dnd";
 import { useTranslation } from "react-i18next";
 import { Card } from "@/components/ui/card";
@@ -24,7 +25,8 @@ interface DraggableElementProps {
   onHover: (elementId: string | null) => void;
 }
 
-export function DraggableElement({ element, onHover }: DraggableElementProps) {
+// ⚡ Bolt: Added React.memo to prevent unnecessary re-renders of list items in DashboardPage when other state changes
+export const DraggableElement = memo(function DraggableElement({ element, onHover }: DraggableElementProps) {
   const { t } = useTranslation();
   const [{ isDragging }, drag] = useDrag(() => ({
     type: "element",
@@ -101,4 +103,4 @@ export function DraggableElement({ element, onHover }: DraggableElementProps) {
       </div>
     </Card>
   );
-}
+});


### PR DESCRIPTION
**What:**
Wrapped the `DraggableElement` component in `React.memo` inside `client/src/components/draggable-element.tsx`.

**Why:**
The `DashboardPage` renders a potentially large list of `DraggableElement` components (detected elements from a website scan). Previously, any state change in `DashboardPage` (e.g., hovering over an element which updates `highlightedElement`) would cause the entire list of elements to re-render. This is highly inefficient and can cause performance bottlenecks as the list grows. By using `React.memo`, we ensure each list item only re-renders if its specific props (`element` or `onHover`) change.

**Impact:**
Significantly reduces React reconciliation time on the `DashboardPage` when interacting with the UI. Hovering over elements and updating the global state will no longer trigger unnecessary re-renders for hundreds of stable list items.

**Measurement:**
You can verify this by checking the React DevTools Profiler while hovering over detected elements on the Dashboard page. The number of components rendering should drop drastically to only the component whose `onHover` is interacting and the `DashboardPage` parent, while the rest of the list remains stable.

---
*PR created automatically by Jules for task [2880523525769131593](https://jules.google.com/task/2880523525769131593) started by @Markg981*