### PR TITLE
⚡ Bolt: [performance improvement] Optimize Playwright browser management using browserPool

### DIFF
--- a/server/playwright-service.ts
+++ b/server/playwright-service.ts
@@ -348,8 +348,9 @@ export class PlaywrightService {
       const effectiveWaitTime = userSettings?.playwrightWaitTime || DEFAULT_WAIT_TIME;
       resolvedLogger.debug({ message: "PS:loadWebsite - Effective settings", browserType, headlessMode, pageTimeout, effectiveWaitTime, userId });
 
-      const browserEngine = playwright[browserType as 'chromium' | 'firefox' | 'webkit'];
-      browser = await browserEngine.launch({ headless: headlessMode });
+      // ⚡ Bolt Optimization: Use browserPool instead of launching a new browser process for every request.
+      // Launching browsers is slow (~500ms+); reusing from pool eliminates this overhead.
+      browser = await (await browserPool).acquire(browserType as 'chromium' | 'firefox' | 'webkit', headlessMode);
       const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'; // Standardized UA
       const context = await browser.newContext({ userAgent });
       const page = await context.newPage();
@@ -387,7 +388,7 @@ export class PlaywrightService {
       };
     } finally {
       if (browser) {
-        await browser.close();
+        await (await browserPool).release(browser);
       }
     }
   }
@@ -871,8 +872,8 @@ export class PlaywrightService {
       }
       resolvedLogger.verbose({ message: "PS:executeAdhocSequence (finally) - State before closing browser", testName, browserExists: !!browser, browserConnected: browser?.isConnected() });
       if (browser && browser.isConnected()) {
-        resolvedLogger.debug({ message: "PS:executeAdhocSequence (finally) - Attempting to close browser...", testName });
-        await browser.close().catch(e => resolvedLogger.warn({ message: "PS:executeAdhocSequence - Error closing browser (adhoc)", testName, error: e.message, stack: e.stack }));
+        resolvedLogger.debug({ message: "PS:executeAdhocSequence (finally) - Attempting to release browser to pool...", testName });
+        await (await browserPool).release(browser).catch(e => resolvedLogger.warn({ message: "PS:executeAdhocSequence - Error releasing browser to pool (adhoc)", testName, error: e.message, stack: e.stack }));
       }
     }
   }
@@ -892,10 +893,10 @@ export class PlaywrightService {
       const pageTimeout = userSettings?.playwrightDefaultTimeout || DEFAULT_TIMEOUT;
       resolvedLogger.debug({ message: "PS:detectElements - Effective settings", browserType, headlessMode, pageTimeout, userId });
 
-      resolvedLogger.debug({ message: "PS:detectElements - Attempting to launch browser", browserType, headlessMode });
-      const browserEngine = playwright[browserType as 'chromium' | 'firefox' | 'webkit'];
-      browser = await browserEngine.launch({ headless: headlessMode });
-      if (!browser) throw new Error("Failed to launch browser");
+      // ⚡ Bolt Optimization: Acquire browser from the pool instead of launching a new one.
+      resolvedLogger.debug({ message: "PS:detectElements - Attempting to acquire browser from pool", browserType, headlessMode });
+      browser = await (await browserPool).acquire(browserType as 'chromium' | 'firefox' | 'webkit', headlessMode);
+      if (!browser) throw new Error("Failed to acquire browser from pool");
 
       const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
       resolvedLogger.debug({ message: "PS:detectElements - Attempting to create new browser context", userAgent });
@@ -944,8 +945,9 @@ export class PlaywrightService {
       }
       resolvedLogger.verbose({ message: "PS:detectElements (finally) - State before closing browser", url, browserExists: !!browser, browserConnected: browser?.isConnected() });
       if (browser && browser.isConnected()) {
-        resolvedLogger.debug({ message: "PS:detectElements (finally) - Attempting to close browser...", url });
-        await browser.close().catch(e => resolvedLogger.warn({ message: "PS:detectElements - Error closing browser", url, error: e.message, stack: e.stack }));
+        // ⚡ Bolt Optimization: Release browser to the pool to prevent leaks instead of destroying it.
+        resolvedLogger.debug({ message: "PS:detectElements (finally) - Attempting to release browser to pool...", url });
+        await (await browserPool).release(browser).catch(e => resolvedLogger.warn({ message: "PS:detectElements - Error releasing browser to pool", url, error: e.message, stack: e.stack }));
       }
     }
   }


### PR DESCRIPTION
💡 **What**: Refactored `loadWebsite`, `detectElements`, and `executeAdhocSequence` in `server/playwright-service.ts` to utilize the `BrowserPool` instead of manually launching and destroying new browser processes. Added proper browser instance releases back to the pool in the `finally` blocks.
🎯 **Why**: Launching a new Playwright browser instance is a highly expensive operation (~500ms - 1s). Re-using browsers from a pool significantly reduces this overhead for short-lived operations like page loading and element detection, minimizing latency and resource exhaustion.
📊 **Impact**: Expected to reduce execution time for ad-hoc tests, element detection, and generic website loads by approximately 500ms to 1s per request. Eliminates resource leaks caused by unreleased browsers.
🔬 **Measurement**: Measure the execution time of `detectElements` or `loadWebsite` before and after this change. Additionally, monitor the number of active browser processes running on the server to ensure they remain within the defined pool limit and do not leak over time.

---
*PR created automatically by Jules for task [15753228356195026584](https://jules.google.com/task/15753228356195026584) started by @Markg981*