### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Avoid Slice in Render]
+**Learning:** Performing `array.slice` on each re-render can be expensive for large data sets, leading to layout jank and high CPU usage if the array is continuously sliced without need.
+**Action:** Always wrap `.slice()` calculations in `useMemo` when calculating paginated views.

--- a/client/src/pages/TestSuitesPage.tsx
+++ b/client/src/pages/TestSuitesPage.tsx
@@ -110,10 +110,14 @@ const TestSuitesPage: React.FC = () => {
   }, [allTestPlans, searchTerm]);
 
   const totalPages = Math.ceil(filteredTestPlans.length / itemsPerPage);
-  const paginatedTestPlans = filteredTestPlans.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage
-  );
+
+  // ⚡ Bolt: Memoize paginated slice to avoid unnecessary array slicing on every render
+  const paginatedTestPlans = useMemo(() => {
+    return filteredTestPlans.slice(
+      (currentPage - 1) * itemsPerPage,
+      currentPage * itemsPerPage
+    );
+  }, [filteredTestPlans, currentPage, itemsPerPage]);
 
   useEffect(() => {
     if (currentPage > totalPages && totalPages > 0) setCurrentPage(totalPages);


### PR DESCRIPTION
💡 What: Wrapped the `paginatedTestPlans` derived array calculation in a `useMemo` hook in `client/src/pages/TestSuitesPage.tsx`. Also added a journal entry in `.jules/bolt.md`.
🎯 Why: The component previously calculated `paginatedTestPlans` by slicing `filteredTestPlans` on every single render. Slicing an array on every render can cause performance issues and unnecessary layout recalculations, especially when only other unrelated state changes.
📊 Impact: Reduces array allocations and slicing operations, preventing unnecessary work during re-renders.
🔬 Measurement: Can be verified using React DevTools Profiler by observing the render times of `TestSuitesPage` when changing non-related state vs when changing pagination/search state.

---
*PR created automatically by Jules for task [5701803667999580510](https://jules.google.com/task/5701803667999580510) started by @Markg981*