### PR TITLE
⚡ Bolt: Fix N+1 query issue in executeTestPlan

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-19 - [Fixing N+1 Queries in Execute Test Plan Loop]
+**Learning:** Found a specific N+1 bottleneck where tests associated with a Test Plan were individually queried from the database inside a `for` loop in `executeTestPlan`. This is an architectural trap in Drizzle codebases looping over associations.
+**Action:** Always batch fetch related models using `inArray` and store them in memory lookup maps (e.g., `new Map()`) prior to looping when dealing with associations in a plan execution context.

--- a/server/test-execution-service.ts
+++ b/server/test-execution-service.ts
@@ -11,7 +11,7 @@ import {
   testPlanExecutions as testPlanExecutionsTable,
   reportTestCaseResults as reportTestCaseResultsTable // Added
 } from '@shared/schema';
-import { eq, and, sql } from 'drizzle-orm'; // Added sql
+import { eq, and, sql, inArray } from 'drizzle-orm'; // Added sql
 import { v4 as uuidv4 } from 'uuid';
 import fs from 'fs-extra';
 import path from 'path';
@@ -206,18 +206,32 @@ export async function runTestPlan(
 
   const legacyIndividualTestResultsForJsonBlob: IndividualTestRunResult[] = [];
 
+  // Bolt Optimization: Batch fetch tests to fix N+1 query issue
+  const uiTestIds = selectedTestsLinks.filter(l => l.testType === 'ui' && l.testId).map(l => l.testId!);
+  const apiTestIds = selectedTestsLinks.filter(l => l.testType === 'api' && l.apiTestId).map(l => l.apiTestId!);
+
+  const uiTestsMap = new Map<number, Test>();
+  if (uiTestIds.length > 0) {
+    const fetchedUiTests = await db.select().from(testsTable).where(inArray(testsTable.id, uiTestIds));
+    fetchedUiTests.forEach(t => uiTestsMap.set(t.id, t as Test));
+  }
+
+  const apiTestsMap = new Map<number, ApiTest>();
+  if (apiTestIds.length > 0) {
+    const fetchedApiTests = await db.select().from(apiTestsTable).where(inArray(apiTestsTable.id, apiTestIds));
+    fetchedApiTests.forEach(t => apiTestsMap.set(t.id, t as ApiTest));
+  }
+
   for (const link of selectedTestsLinks) {
     let testObjectDefinition: Test | ApiTest | undefined;
     let testTypeForRun: 'ui' | 'api' | undefined = link.testType as ('ui' | 'api');
 
     if (link.testId && link.testType === 'ui') {
-      // Fetch UI test with new metadata fields
-      const uiTestArr = await db.select().from(testsTable).where(eq(testsTable.id, link.testId)).limit(1);
-      if (uiTestArr.length > 0) testObjectDefinition = uiTestArr[0];
+      // Bolt Optimization: Use lookup map instead of DB query
+      testObjectDefinition = uiTestsMap.get(link.testId);
     } else if (link.apiTestId && link.testType === 'api') {
-      // Fetch API test with new metadata fields
-      const apiTestArr = await db.select().from(apiTestsTable).where(eq(apiTestsTable.id, link.apiTestId)).limit(1);
-      if (apiTestArr.length > 0) testObjectDefinition = apiTestArr[0];
+      // Bolt Optimization: Use lookup map instead of DB query
+      testObjectDefinition = apiTestsMap.get(link.apiTestId);
     }
 
     const singleTestStartTime = Date.now();


### PR DESCRIPTION
⚡ Bolt: [performance improvement]
* 💡 What: Replaced individual database queries inside the executeTestPlan loop with batched queries using Drizzle's `inArray` and lookup maps.
* 🎯 Why: Solves an N+1 query problem that severely delayed test plan executions as the number of linked tests increased.
* 📊 Impact: Reduces O(N) database trips to O(1) query trips per plan run, significantly dropping test plan startup latency.
* 🔬 Measurement: Observe DB logs or latency metrics when running a test plan with numerous tests.

---
*PR created automatically by Jules for task [11105890911916281306](https://jules.google.com/task/11105890911916281306) started by @Markg981*