### PR TITLE
⚡ Bolt: [performance improvement] fix N+1 queries in test execution

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-20 - [Fixing N+1 Queries in test plan executions]
+**Learning:** `executeTestPlan` in `test-execution-service.ts` had an N+1 query loop when reading ui or api test metadata for every test link execution.
+**Action:** Always batch fetch ORM records with `inArray()` instead of iterating inside a for loop, storing fetched arrays into `Map()` for O(1) loop retrieval.

--- a/server/test-execution-service.ts
+++ b/server/test-execution-service.ts
@@ -11,7 +11,7 @@ import {
   testPlanExecutions as testPlanExecutionsTable,
   reportTestCaseResults as reportTestCaseResultsTable // Added
 } from '@shared/schema';
-import { eq, and, sql } from 'drizzle-orm'; // Added sql
+import { eq, and, sql, inArray } from 'drizzle-orm'; // Added sql
 import { v4 as uuidv4 } from 'uuid';
 import fs from 'fs-extra';
 import path from 'path';
@@ -204,6 +204,25 @@ export async function runTestPlan(
     .from(testPlanSelectedTests)
     .where(eq(testPlanSelectedTests.testPlanId, planId));
 
+  // ⚡ Bolt Performance Optimization:
+  // N+1 Query Fix: Batch fetch all related UI and API tests outside the loop
+  // instead of querying the database individually for each selected test link.
+  // This reduces N queries to just 2 queries, significantly improving test plan execution speed.
+  const uiTestIds = selectedTestsLinks.filter(link => link.testType === 'ui' && link.testId).map(link => link.testId as number);
+  const apiTestIds = selectedTestsLinks.filter(link => link.testType === 'api' && link.apiTestId).map(link => link.apiTestId as number);
+
+  const uiTestsMap = new Map<number, Test>();
+  if (uiTestIds.length > 0) {
+    const fetchedUiTests = await db.select().from(testsTable).where(inArray(testsTable.id, uiTestIds));
+    fetchedUiTests.forEach(test => uiTestsMap.set(test.id, test as Test));
+  }
+
+  const apiTestsMap = new Map<number, ApiTest>();
+  if (apiTestIds.length > 0) {
+    const fetchedApiTests = await db.select().from(apiTestsTable).where(inArray(apiTestsTable.id, apiTestIds));
+    fetchedApiTests.forEach(test => apiTestsMap.set(test.id, test as ApiTest));
+  }
+
   const legacyIndividualTestResultsForJsonBlob: IndividualTestRunResult[] = [];
 
   for (const link of selectedTestsLinks) {
@@ -211,13 +230,9 @@ export async function runTestPlan(
     let testTypeForRun: 'ui' | 'api' | undefined = link.testType as ('ui' | 'api');
 
     if (link.testId && link.testType === 'ui') {
-      // Fetch UI test with new metadata fields
-      const uiTestArr = await db.select().from(testsTable).where(eq(testsTable.id, link.testId)).limit(1);
-      if (uiTestArr.length > 0) testObjectDefinition = uiTestArr[0];
+      testObjectDefinition = uiTestsMap.get(link.testId);
     } else if (link.apiTestId && link.testType === 'api') {
-      // Fetch API test with new metadata fields
-      const apiTestArr = await db.select().from(apiTestsTable).where(eq(apiTestsTable.id, link.apiTestId)).limit(1);
-      if (apiTestArr.length > 0) testObjectDefinition = apiTestArr[0];
+      testObjectDefinition = apiTestsMap.get(link.apiTestId);
     }
 
     const singleTestStartTime = Date.now();


### PR DESCRIPTION
**What**: Replaced sequential, individual database queries (`db.select()`) inside the `executeTestPlan` loop with pre-fetched batched queries using `inArray()`. The results are loaded into a `Map` structure for O(1) retrieval during the execution loop.

**Why**: An N+1 query vulnerability exists where executing a test plan forces the server to reach out to the database exactly N times per N tests selected in that plan. This results in heavy roundtrip bottlenecking for large regression test sweeps. 

**Impact**: Expected improvement is an O(N) -> O(1) database query reduction. Running a test plan with 100 tests will now perform just 2 fast DB queries instead of 100 roundtrip queries, significantly improving memory and runtime execution for test runners.

**Measurement**: Verification can be seen by checking DB execution metrics or logging the time taken across the loop block with and without the PR changes over large test suites.

---
*PR created automatically by Jules for task [15039374642235406458](https://jules.google.com/task/15039374642235406458) started by @Markg981*