### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-24 - [Drizzle ORM N+1]
+**Learning:** This codebase executes automated test plans containing multiple UI and API tests. Loading their definitions individually within the execution loop creates an N+1 query bottleneck using Drizzle ORM against SQLite.
+**Action:** Always map associations beforehand by extracting IDs, doing one batch fetch with `inArray`, and storing the items in an O(1) Javascript `Map` for quick lookups during the main execution loop.

--- a/server/test-execution-service.ts
+++ b/server/test-execution-service.ts
@@ -11,7 +11,7 @@ import {
   testPlanExecutions as testPlanExecutionsTable,
   reportTestCaseResults as reportTestCaseResultsTable // Added
 } from '@shared/schema';
-import { eq, and, sql } from 'drizzle-orm'; // Added sql
+import { eq, and, sql, inArray } from 'drizzle-orm'; // Added sql
 import { v4 as uuidv4 } from 'uuid';
 import fs from 'fs-extra';
 import path from 'path';
@@ -206,18 +206,32 @@ export async function runTestPlan(
 
   const legacyIndividualTestResultsForJsonBlob: IndividualTestRunResult[] = [];
 
+  // ⚡ Bolt: N+1 Optimization - Batch fetch tests instead of querying inside loop
+  const uiTestIds = selectedTestsLinks.filter(l => l.testType === 'ui' && l.testId).map(l => l.testId as number);
+  const apiTestIds = selectedTestsLinks.filter(l => l.testType === 'api' && l.apiTestId).map(l => l.apiTestId as number);
+
+  const uiTestsMap = new Map<number, Test>();
+  if (uiTestIds.length > 0) {
+    const uiTests = await db.select().from(testsTable).where(inArray(testsTable.id, uiTestIds));
+    for (const test of uiTests) uiTestsMap.set(test.id, test);
+  }
+
+  const apiTestsMap = new Map<number, ApiTest>();
+  if (apiTestIds.length > 0) {
+    const apiTests = await db.select().from(apiTestsTable).where(inArray(apiTestsTable.id, apiTestIds));
+    for (const test of apiTests) apiTestsMap.set(test.id, test);
+  }
+
   for (const link of selectedTestsLinks) {
     let testObjectDefinition: Test | ApiTest | undefined;
     let testTypeForRun: 'ui' | 'api' | undefined = link.testType as ('ui' | 'api');
 
     if (link.testId && link.testType === 'ui') {
-      // Fetch UI test with new metadata fields
-      const uiTestArr = await db.select().from(testsTable).where(eq(testsTable.id, link.testId)).limit(1);
-      if (uiTestArr.length > 0) testObjectDefinition = uiTestArr[0];
+      // ⚡ Bolt: O(1) memory lookup map
+      testObjectDefinition = uiTestsMap.get(link.testId);
     } else if (link.apiTestId && link.testType === 'api') {
-      // Fetch API test with new metadata fields
-      const apiTestArr = await db.select().from(apiTestsTable).where(eq(apiTestsTable.id, link.apiTestId)).limit(1);
-      if (apiTestArr.length > 0) testObjectDefinition = apiTestArr[0];
+      // ⚡ Bolt: O(1) memory lookup map
+      testObjectDefinition = apiTestsMap.get(link.apiTestId);
     }
 
     const singleTestStartTime = Date.now();


### PR DESCRIPTION
💡 What: Replaced individual database queries inside the test execution loop with batched `inArray` queries. The fetched test definitions are now stored in an O(1) JavaScript `Map` for fast lookup during execution.
🎯 Why: Resolves a classic N+1 query bottleneck that occurs when loading test definitions sequentially within the main test execution sequence, slowing down test plan starts as the number of associated tests grows.
📊 Impact: Reduces database queries during execution setup from O(N) to O(1) for test definitions, improving the execution service's time complexity and reducing SQLite roundtrips.
🔬 Measurement: Run a large test plan and trace database queries; observe fewer `SELECT` queries to `tests` and `apiTests` tables per execution run.

---
*PR created automatically by Jules for task [14058607273420218477](https://jules.google.com/task/14058607273420218477) started by @Markg981*