### PR TITLE
⚡ Bolt: [performance improvement] Batch test lookups to resolve N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-09 - N+1 Query Elimination using Hash Map Lookup
+**Learning:** Found an N+1 query bottleneck in `server/test-execution-service.ts` where looping over test plan relations (`testPlanSelectedTests`) caused sequential database requests for each associated UI (`testsTable`) and API (`apiTestsTable`) test definition.
+**Action:** Implemented O(1) in-memory lookups by extracting IDs, batching database queries upfront using Drizzle ORM's `inArray()`, and storing entities in `Map<number, Test>` and `Map<number, ApiTest>`. Avoid using `inArray` with empty arrays to prevent SQL runtime errors. Always extract arrays and query conditionally (`if (ids.length > 0)`).

--- a/server/test-execution-service.ts
+++ b/server/test-execution-service.ts
@@ -11,7 +11,7 @@ import {
   testPlanExecutions as testPlanExecutionsTable,
   reportTestCaseResults as reportTestCaseResultsTable // Added
 } from '@shared/schema';
-import { eq, and, sql } from 'drizzle-orm'; // Added sql
+import { eq, and, sql, inArray } from 'drizzle-orm'; // Added sql
 import { v4 as uuidv4 } from 'uuid';
 import fs from 'fs-extra';
 import path from 'path';
@@ -206,18 +206,30 @@ export async function runTestPlan(
 
   const legacyIndividualTestResultsForJsonBlob: IndividualTestRunResult[] = [];
 
+  // Batch fetch UI tests to prevent N+1 queries
+  const uiTestIds = selectedTestsLinks.filter(link => link.testId && link.testType === 'ui').map(link => link.testId as number);
+  const uiTestsMap = new Map<number, Test>();
+  if (uiTestIds.length > 0) {
+    const uiTests = await db.select().from(testsTable).where(inArray(testsTable.id, uiTestIds));
+    uiTests.forEach(test => uiTestsMap.set(test.id, test));
+  }
+
+  // Batch fetch API tests to prevent N+1 queries
+  const apiTestIds = selectedTestsLinks.filter(link => link.apiTestId && link.testType === 'api').map(link => link.apiTestId as number);
+  const apiTestsMap = new Map<number, ApiTest>();
+  if (apiTestIds.length > 0) {
+    const apiTests = await db.select().from(apiTestsTable).where(inArray(apiTestsTable.id, apiTestIds));
+    apiTests.forEach(test => apiTestsMap.set(test.id, test));
+  }
+
   for (const link of selectedTestsLinks) {
     let testObjectDefinition: Test | ApiTest | undefined;
     let testTypeForRun: 'ui' | 'api' | undefined = link.testType as ('ui' | 'api');
 
     if (link.testId && link.testType === 'ui') {
-      // Fetch UI test with new metadata fields
-      const uiTestArr = await db.select().from(testsTable).where(eq(testsTable.id, link.testId)).limit(1);
-      if (uiTestArr.length > 0) testObjectDefinition = uiTestArr[0];
+      testObjectDefinition = uiTestsMap.get(link.testId);
     } else if (link.apiTestId && link.testType === 'api') {
-      // Fetch API test with new metadata fields
-      const apiTestArr = await db.select().from(apiTestsTable).where(eq(apiTestsTable.id, link.apiTestId)).limit(1);
-      if (apiTestArr.length > 0) testObjectDefinition = apiTestArr[0];
+      testObjectDefinition = apiTestsMap.get(link.apiTestId);
     }
 
     const singleTestStartTime = Date.now();


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Batch test lookups to resolve N+1 queries

What: Replaced sequential `db.select()` inside a loop with batch lookups using `inArray()` and storing results in O(1) retrieval `Map`s.
Why: Previously `server/test-execution-service.ts` had an N+1 query issue for test fetching during test plan execution.
Impact: Reduces execution time specifically when executing test plans with numerous UI and API tests.
Measurement: Compare database query counts and overall latency of the test execution pipeline for large plans.

---
*PR created automatically by Jules for task [5162770892171130316](https://jules.google.com/task/5162770892171130316) started by @Markg981*