### PR TITLE
⚡ Bolt: [performance improvement] Batch fetch tests in test execution service

### DIFF
--- a/server/test-execution-service.ts
+++ b/server/test-execution-service.ts
@@ -11,7 +11,7 @@ import {
   testPlanExecutions as testPlanExecutionsTable,
   reportTestCaseResults as reportTestCaseResultsTable // Added
 } from '@shared/schema';
-import { eq, and, sql } from 'drizzle-orm'; // Added sql
+import { eq, and, sql, inArray } from 'drizzle-orm'; // Added sql
 import { v4 as uuidv4 } from 'uuid';
 // @ts-ignore - no @types/fs-extra installed
 import fs from 'fs-extra';
@@ -305,18 +305,32 @@ export async function processTestPlanJob(
 
   const legacyIndividualTestResultsForJsonBlob: IndividualTestRunResult[] = [];
 
+  // ⚡ Bolt: Batch fetch tests to resolve N+1 query performance bottleneck.
+  // Why: Previously, tests were queried individually inside the loop (O(N) queries).
+  // Impact: Reduces DB queries from N to 2, significantly improving test plan execution initialization.
+  const uiTestIds = selectedTestsLinks.filter(l => l.testType === 'ui' && l.testId).map(l => l.testId as number);
+  const apiTestIds = selectedTestsLinks.filter(l => l.testType === 'api' && l.apiTestId).map(l => l.apiTestId as number);
+
+  const uiTestsMap = new Map<number, Test>();
+  if (uiTestIds.length > 0) {
+    const uiTestsArr = await db.select().from(testsTable).where(inArray(testsTable.id, uiTestIds));
+    uiTestsArr.forEach(t => uiTestsMap.set(t.id, t as Test));
+  }
+
+  const apiTestsMap = new Map<number, ApiTest>();
+  if (apiTestIds.length > 0) {
+    const apiTestsArr = await db.select().from(apiTestsTable).where(inArray(apiTestsTable.id, apiTestIds));
+    apiTestsArr.forEach(t => apiTestsMap.set(t.id, t as ApiTest));
+  }
+
   for (const link of selectedTestsLinks) {
     let testObjectDefinition: Test | ApiTest | undefined;
     let testTypeForRun: 'ui' | 'api' | undefined = link.testType as ('ui' | 'api');
 
     if (link.testId && link.testType === 'ui') {
-      // Fetch UI test with new metadata fields
-      const uiTestArr = await db.select().from(testsTable).where(eq(testsTable.id, link.testId)).limit(1);
-      if (uiTestArr.length > 0) testObjectDefinition = uiTestArr[0];
+      testObjectDefinition = uiTestsMap.get(link.testId);
     } else if (link.apiTestId && link.testType === 'api') {
-      // Fetch API test with new metadata fields
-      const apiTestArr = await db.select().from(apiTestsTable).where(eq(apiTestsTable.id, link.apiTestId)).limit(1);
-      if (apiTestArr.length > 0) testObjectDefinition = apiTestArr[0];
+      testObjectDefinition = apiTestsMap.get(link.apiTestId);
     }
 
     const singleTestStartTime = Date.now();


### PR DESCRIPTION
💡 What: Refactored the `processTestPlanJob` function in `server/test-execution-service.ts` to batch-fetch associated tests (UI and API) before entering the loop that processes the selected test links. It now uses Drizzle ORM's `inArray` to query tests in bulk and stores them in memory mapping (`Map`) for O(1) lookup.

🎯 Why: To solve an N+1 query problem. Previously, for a test plan with N tests, it would execute N individual database queries sequentially inside the loop to fetch each test's definition.

📊 Impact: Reduces the number of database queries during test plan initialization from O(N) to exactly 2 (one for UI tests, one for API tests), which significantly speeds up initialization times for test plans with a large number of tests.

🔬 Measurement: Verify the change by running a test plan with a large number of tests and observing the query logs and the overall execution duration of the backend `runTestPlan` processing. It can be further verified by ensuring the backend test suites (`npm run test`) continue to pass.

---
*PR created automatically by Jules for task [17012687410934184876](https://jules.google.com/task/17012687410934184876) started by @Markg981*