### PR TITLE
⚡ Bolt: [performance improvement] Resolve N+1 query problem

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - N+1 Query in Test Plan Execution
+**Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
+**Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.

--- a/server/test-execution-service.ts
+++ b/server/test-execution-service.ts
@@ -11,7 +11,7 @@ import {
   testPlanExecutions as testPlanExecutionsTable,
   reportTestCaseResults as reportTestCaseResultsTable // Added
 } from '@shared/schema';
-import { eq, and, sql } from 'drizzle-orm'; // Added sql
+import { eq, and, sql, inArray } from 'drizzle-orm'; // Added sql
 import { v4 as uuidv4 } from 'uuid';
 // @ts-ignore - no @types/fs-extra installed
 import fs from 'fs-extra';
@@ -303,6 +303,25 @@ export async function processTestPlanJob(
     timestamp: new Date().toISOString()
   });
 
+  // ⚡ BOLT OPTIMIZATION: Resolve N+1 query problem by batch-fetching all required
+  // UI and API test definitions in a single database roundtrip.
+  // Using Map for O(1) in-memory lookups during the sequential execution loop.
+  // This significantly reduces DB load and latency for plans with many tests.
+  const uiTestIds = selectedTestsLinks.filter(l => l.testType === 'ui' && l.testId).map(l => l.testId as number);
+  const apiTestIds = selectedTestsLinks.filter(l => l.testType === 'api' && l.apiTestId).map(l => l.apiTestId as number);
+
+  const uiTestsMap = new Map<number, Test>();
+  if (uiTestIds.length > 0) {
+    const uiTests = await db.select().from(testsTable).where(inArray(testsTable.id, uiTestIds));
+    uiTests.forEach(t => uiTestsMap.set(t.id, t as Test));
+  }
+
+  const apiTestsMap = new Map<number, ApiTest>();
+  if (apiTestIds.length > 0) {
+    const apiTests = await db.select().from(apiTestsTable).where(inArray(apiTestsTable.id, apiTestIds));
+    apiTests.forEach(t => apiTestsMap.set(t.id, t as ApiTest));
+  }
+
   const legacyIndividualTestResultsForJsonBlob: IndividualTestRunResult[] = [];
 
   for (const link of selectedTestsLinks) {
@@ -310,13 +329,9 @@ export async function processTestPlanJob(
     let testTypeForRun: 'ui' | 'api' | undefined = link.testType as ('ui' | 'api');
 
     if (link.testId && link.testType === 'ui') {
-      // Fetch UI test with new metadata fields
-      const uiTestArr = await db.select().from(testsTable).where(eq(testsTable.id, link.testId)).limit(1);
-      if (uiTestArr.length > 0) testObjectDefinition = uiTestArr[0];
+      testObjectDefinition = uiTestsMap.get(link.testId);
     } else if (link.apiTestId && link.testType === 'api') {
-      // Fetch API test with new metadata fields
-      const apiTestArr = await db.select().from(apiTestsTable).where(eq(apiTestsTable.id, link.apiTestId)).limit(1);
-      if (apiTestArr.length > 0) testObjectDefinition = apiTestArr[0];
+      testObjectDefinition = apiTestsMap.get(link.apiTestId);
     }
 
     const singleTestStartTime = Date.now();


### PR DESCRIPTION
💡 **What**: Refactored `runTestPlan` in `server/test-execution-service.ts` to batch fetch required UI and API tests using the `inArray` Drizzle operator and Map objects.
🎯 **Why**: The execution loop had an N+1 query problem, fetching the definition for each test independently via a database call, creating latency and unnecessary database load.
📊 **Impact**: Reduces execution database query roundtrips from O(N) where N is the number of scheduled tests, down to a maximum of 2 batched queries, offering a significant speed boost for test plans with multiple tests.
🔬 **Measurement**: Verify by creating a test plan with several UI and API tests, execute the test plan, and monitor server logs and database queries for a drastic reduction in sequential lookups.

---
*PR created automatically by Jules for task [8817590491943677161](https://jules.google.com/task/8817590491943677161) started by @Markg981*