### PR TITLE
⚡ Bolt: [performance improvement] DB pagination for selectable tests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+## 2024-05-24 - O(N) Memory Bottleneck in In-Memory Pagination
+**Learning:** Combining data from `tests` and `apiTests` tables by fetching all matching rows into arrays and slicing them in Node.js memory (`server/routes.ts` `/api/selectable-tests`) creates an O(N) memory and processing bottleneck that fails to scale for users with many tests.
+**Action:** Use Drizzle ORM's `unionAll` (from `drizzle-orm/pg-core`) combined with `orderBy`, `limit`, and `offset` to perform sorting and pagination directly within the database query instead of in application memory.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1684,8 +1685,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         apiConditions.push(ilike(apiTests.name, searchPattern));
       }
 
-      // Execute queries
-      const uiTestResults = await db.select({
+      // ⚡ BOLT OPTIMIZATION: Push pagination, sorting, and union to the database
+      // Previously, all tests were loaded into Node memory, combined, sorted, and sliced.
+      // This caused an O(N) memory bottleneck and slow request times for large accounts.
+
+      const uiTestsQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1699,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiTestsQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,19 +1709,19 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // 1. Fetch exactly what's needed for the current page
+      const paginatedItems = await unionAll(uiTestsQuery, apiTestsQuery)
+        .orderBy(asc(sql`name`))
+        .limit(limit)
+        .offset(offset);
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
+      // 2. Fast count queries avoiding row data extraction
+      const [uiCountResult, apiCountResult] = await Promise.all([
+        db.select({ count: sql<number>`count(*)` }).from(tests).where(and(...uiConditions)),
+        db.select({ count: sql<number>`count(*)` }).from(apiTests).where(and(...apiConditions))
+      ]);
 
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      const totalItems = Number(uiCountResult[0].count) + Number(apiCountResult[0].count);
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 What: Replaced in-memory sorting and array slicing of combined UI/API tests with a database-level `UNION ALL` query using `limit`, `offset`, and `orderBy`. Fast aggregate queries were added for the total pagination counts.
🎯 Why: Previously, the `/api/selectable-tests` route loaded all matching rows from both the `tests` and `apiTests` tables into Node.js memory, concatenated them, sorted them using `.sort()`, and then sliced the arrays. For large accounts, this was a severe O(N) memory bottleneck, causing increased garbage collection, high response latencies, and unnecessary DB load.
📊 Impact: Reduces peak memory consumption for this route from O(N) to O(1) (where N is total matching tests), pushing computation efficiently to PostgreSQL/SQLite, significantly reducing API response latency and DB payload sizes for accounts with many tests.
🔬 Measurement: Verified via `npm run check` and `npm test` passing successfully. Review API response latency on `/api/selectable-tests` when `limit`=10 for an account with >1000 items; the query now pulls 10 rows instead of 1000+.

---
*PR created automatically by Jules for task [12727576876236498216](https://jules.google.com/task/12727576876236498216) started by @Markg981*