### PR TITLE
⚡ Bolt: Optimize /api/selectable-tests pagination by pushing sorting/limiting to DB

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+
+## 2024-05-24 - O(N) Memory in Pagination
+**Learning:** The `/api/selectable-tests` endpoint was executing queries without limits, loading entire datasets into Node.js memory just to slice arrays for pagination.
+**Action:** Always use database-level pagination combined with `unionAll` (from `drizzle-orm/pg-core`) instead of `Array.prototype.slice()` and JS-side `.sort()` when combining results from multiple tables.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1685,7 +1686,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Execute queries
-      const uiTestResults = await db.select({
+      const uiTestResults = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1696,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiTestResults = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,19 +1706,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // ⚡ Bolt: Combine results at the DB level using unionAll to avoid O(N) memory allocation and in-memory sorting
+      const combinedQuery = unionAll(uiTestResults, apiTestResults).as('combined_tests');
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
+      const totalItemsResult = await db.select({ count: sql<number>`count(*)` }).from(combinedQuery);
+      const totalItems = Number(totalItemsResult[0].count);
 
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      const paginatedItems = await db.select()
+        .from(combinedQuery)
+        .orderBy(asc(combinedQuery.name))
+        .limit(limit)
+        .offset(offset);
+
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 **What:** Replaced in-memory concatenation, sorting, and slicing of `uiTestResults` and `apiTestResults` with Drizzle ORM's database-level `unionAll`, `limit`, `offset`, and `orderBy`.

🎯 **Why:** Previously, the `/api/selectable-tests` endpoint queried all matching tests without bounds, loading the entire dataset into Node.js memory just to apply pagination. This created an O(N) memory footprint and a processing bottleneck, which would cause massive load times and potential OOM crashes on large workspaces.

📊 **Impact:** Reduces memory usage from O(N) to O(1) for this endpoint and drastically improves response time for workspaces with hundreds/thousands of tests by shifting the aggregation and sorting burden to the Postgres engine.

🔬 **Measurement:** Verify by observing CPU/Memory profiles when repeatedly hitting the `/api/selectable-tests?page=1&limit=10` endpoint with thousands of mocked `tests` and `api_tests` rows in the database.

---
*PR created automatically by Jules for task [16171900641930514538](https://jules.google.com/task/16171900641930514538) started by @Markg981*