### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+## 2026-05-13 - O(N) Memory Pagination fix
+**Learning:** In `server/routes.ts`, the `GET /api/selectable-tests` endpoint was fetching all records into memory, sorting them, and then paginating. This caused an O(N) memory bottleneck for large result sets.
+**Action:** Use Drizzle ORM's `unionAll` (imported from `drizzle-orm/pg-core`) to combine multiple queries, then apply `.orderBy()`, `.limit()`, and `.offset()` directly on the union query to perform pagination and sorting at the database level.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1685,7 +1686,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Execute queries
-      const uiTestResults = await db.select({
+      const uiQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1696,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,19 +1706,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      const uiCountResult = await db.select({ count: sql<number>`count(*)` }).from(tests).where(and(...uiConditions));
+      const apiCountResult = await db.select({ count: sql<number>`count(*)` }).from(apiTests).where(and(...apiConditions));
+      const totalItems = Number(uiCountResult[0].count) + Number(apiCountResult[0].count);
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
+      // Paginated combined results using unionAll
+      const paginatedItems = await unionAll(uiQuery, apiQuery)
+        .orderBy(asc(sql`name`))
+        .limit(limit)
+        .offset(offset);
 
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 **What**: Replaced in-memory array concatenation, sorting, and pagination with Drizzle ORM's `unionAll()` and database-level `.orderBy()`, `.limit()`, and `.offset()` in the `GET /api/selectable-tests` endpoint.
🎯 **Why**: Previously, all UI and API tests were fetched into Node.js memory, concatenated, sorted using `localeCompare()`, and then paginated via `.slice()`. For workspaces with many tests, this causes a severe O(N) memory and compute bottleneck.
📊 **Impact**: Reduces memory usage and processing time from O(N) to O(1) by pushing pagination and sorting to the PostgreSQL/PGlite database.
🔬 **Measurement**: Verify that requests to `GET /api/selectable-tests` successfully return paginated tests and that the `totalItems` count is preserved correctly.

---
*PR created automatically by Jules for task [10159137424300820165](https://jules.google.com/task/10159137424300820165) started by @Markg981*