### PR TITLE
⚡ Bolt: [performance improvement] Optimize /api/selectable-tests pagination using DB unionAll

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+
+## 2023-10-27 - Drizzle unionAll Order By Gotcha
+**Learning:** When using `unionAll` in Drizzle ORM, applying `orderBy(asc(table.column))` can result in invalid SQL because table aliases are often lost in the union projection.
+**Action:** Use `orderBy(sql\`column_name ASC\`)` instead to reference the correctly projected column name in the union result without table qualification.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -44,6 +44,7 @@ import {
 import { z } from "zod";
 import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
+import { unionAll } from "drizzle-orm/pg-core";
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
 import { playwrightService } from "./playwright-service";
@@ -1684,40 +1685,35 @@ export async function registerRoutes(app: Express): Promise<Server> {
         apiConditions.push(ilike(apiTests.name, searchPattern));
       }
 
-      // Execute queries
-      const uiTestResults = await db.select({
+      // Execute queries using unionAll for optimal O(1) pagination at the DB level
+      const uiQuery = db.select({
           id: tests.id,
           name: tests.name,
-          description: sql<string>`null`.as('description'),
+          description: sql<string | null>`null`.as('description'),
           type: sql<string>`'ui'`.as('type'),
           updatedAt: tests.updatedAt
         })
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
-          description: sql<string>`null`.as('description'),
+          description: sql<string | null>`null`.as('description'),
           type: sql<string>`'api'`.as('type'),
           updatedAt: apiTests.updatedAt
         })
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      const paginatedItems = await unionAll(uiQuery, apiQuery)
+        .orderBy(sql`name ASC`)
+        .limit(limit)
+        .offset(offset);
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
-
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      const uiCountResult = await db.select({ count: sql`count(*)` }).from(tests).where(and(...uiConditions));
+      const apiCountResult = await db.select({ count: sql`count(*)` }).from(apiTests).where(and(...apiConditions));
+      const totalItems = Number(uiCountResult[0].count) + Number(apiCountResult[0].count);
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 What: Replaced in-memory combining and pagination of API and UI tests with a database-level `unionAll` operation featuring native limit, offset, and sorting.
🎯 Why: The previous `/api/selectable-tests` endpoint fetched potentially unbounded arrays from two tables, combined them in JavaScript, and then paginated. This would lead to severe memory bloat and slow responses as the number of tests grew (O(N) data transfer and processing).
📊 Impact: Expected to reduce memory consumption significantly and provide O(1) response times relative to total dataset size (bounded strictly by the limit size instead of scanning and fetching all records).
🔬 Measurement: Verify by checking network response time and server memory profile when loading the Selectable Tests modal for Test Plans, specifically for users with a large number of tests.

---
*PR created automatically by Jules for task [8219766566227762299](https://jules.google.com/task/8219766566227762299) started by @Markg981*