### PR TITLE
⚡ Bolt: Optimize selectable tests API with database union and pagination

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+
+## 2024-05-24 - Database Level Pagination using unionAll
+**Learning:** Combining data from multiple tables by fetching all rows into memory and slicing them using `Array.prototype.slice()` creates an O(N) memory bottleneck and severely degrades performance on large datasets.
+**Action:** Use Drizzle ORM's `unionAll` to combine subqueries and apply `.limit()`, `.offset()`, and `.orderBy()` directly on the union query to perform sorting and pagination at the database level.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1685,7 +1686,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Execute queries
-      const uiTestResults = await db.select({
+      const uiQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1696,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1706,18 +1707,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .where(and(...apiConditions));
 
       // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // ⚡ Bolt: Use unionAll to combine queries and perform pagination at the database level
+      // This prevents O(N) memory bottlenecks when paginating and combining data from multiple tables
+      const unionQuery = unionAll(uiQuery, apiQuery).as('combined_tests');
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
+      const [paginatedItems, totalCountResult] = await Promise.all([
+        db.select()
+          .from(unionQuery)
+          .orderBy(asc(unionQuery.name))
+          .limit(limit)
+          .offset(offset),
+        db.select({ count: sql<number>`count(*)::int` })
+          .from(unionQuery)
+      ]);
 
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      const totalItems = totalCountResult[0]?.count || 0;
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 What: Refactored the `GET /api/selectable-tests` endpoint to use Drizzle ORM's `unionAll` operator. This pushes the combining, sorting, and pagination logic down to the PostgreSQL database level instead of performing it in application memory.

🎯 Why: Previously, the endpoint fetched all matching records from the `tests` and `api_tests` tables into Node.js memory arrays, combined them using the spread operator, sorted them via `Array.prototype.sort()`, and paginated them using `Array.prototype.slice()`. For large numbers of tests, this was an O(N) memory and processing bottleneck that could easily cause performance degradation or out-of-memory errors.

📊 Impact: Reduces Node.js memory footprint to O(1) for this operation. Speeds up request latency as the database engines are heavily optimized for set operations (`UNION ALL`) and cursor limits (`LIMIT`/`OFFSET`). 

🔬 Measurement: Check the API response time and memory usage when making a request to `/api/selectable-tests?limit=10&page=1` on a large dataset. The result should be instantly returned without any memory spikes on the application server.

---
*PR created automatically by Jules for task [1983258405822916793](https://jules.google.com/task/1983258405822916793) started by @Markg981*