### PR TITLE
⚡ Bolt: [performance improvement] O(N) Memory Pagination with UnionAll

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+
+## 2026-05-17 - O(N) Memory Pagination with UnionAll
+**Learning:** In endpoints that aggregate multiple entity types (e.g., UI tests and API tests) and paginate the results, fetching all rows into memory and using array concatenations and `.slice()` causes significant O(N) memory allocation and processing overhead as the tables grow.
+**Action:** Use Drizzle ORM's `unionAll` (imported from `drizzle-orm/pg-core` for Postgres/PGlite). Pass unawaited query builders to `unionAll` and append `.limit()`, `.offset()`, and `.orderBy()` on the combined result to perform pagination directly at the database level.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1685,7 +1686,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Execute queries
-      const uiTestResults = await db.select({
+      const uiTestQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1696,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiTestQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,20 +1706,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // ⚡ BOLT OPTIMIZATION: Resolves O(N) memory bottleneck by doing pagination directly at the database level.
+      const combinedQuery = unionAll(uiTestQuery, apiTestQuery);
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
-
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      const countResult = await db.select({ count: sql<number>`count(*)` }).from(combinedQuery.as('combined_count'));
+      const totalItems = Number(countResult[0]?.count || 0);
       const totalPages = Math.ceil(totalItems / limit);
+
+      const paginatedItems = await db.select()
+        .from(combinedQuery.as('combined_data'))
+        .orderBy(asc(sql`name`))
+        .limit(limit)
+        .offset(offset);
 
       res.json({
         items: paginatedItems,


### PR DESCRIPTION
💡 **What:** Refactored the `/api/selectable-tests` endpoint to replace the manual `[...uiTestResults, ...apiTestResults]` array concatenation, `.sort()`, and `.slice()` operations with Drizzle ORM's `unionAll`. The endpoint now correctly resolves sorting and pagination at the database level by selecting from the wrapped combined subquery.

🎯 **Why:** Previously, the server fetched *every single* UI test and API test belonging to a user from the database directly into Node.js memory, concatenated them into a single giant array, sorted them via a JavaScript callback, and manually sliced them to create a single page. This creates a severe O(N) memory allocation and processing bottleneck, which would cause endpoint latency to dramatically spike and potentially trigger V8 out-of-memory crashes as the number of tests in the user's account grows. 

📊 **Impact:** Reduces memory overhead for this endpoint from O(N) (relative to the total number of tests) to O(1) by only returning the 10 rows requested in the `LIMIT` statement. Database query execution time and node event loop blocking are also substantially reduced.

🔬 **Measurement:** To verify the improvement, create thousands of mock tests, hit the `/api/selectable-tests` endpoint, and compare memory profiles before and after this change. Alternatively, view the response payload ensuring pagination behavior matches expectations without needing to fetch the whole table.

---
*PR created automatically by Jules for task [14323758110334223265](https://jules.google.com/task/14323758110334223265) started by @Markg981*