### PR TITLE
⚡ Bolt: Prevent O(N) memory bottleneck in selectable-tests pagination

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+
+## 2024-06-25 - O(N) Array memory slice in pagination
+**Learning:** The `/api/selectable-tests` endpoint was loading all `tests` and `apiTests` models into a Javascript array, sorting them, and then using `.slice()` to paginate. This requires O(N) memory.
+**Action:** Use Drizzle ORM's `unionAll` to combine unawaited queries and perform pagination directly at the database level with `.orderBy()`, `.limit()`, and `.offset()`.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1684,8 +1685,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         apiConditions.push(ilike(apiTests.name, searchPattern));
       }
 
-      // Execute queries
-      const uiTestResults = await db.select({
+      // Execute queries without awaiting to build query objects for unionAll
+      const uiQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1696,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,19 +1706,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // ⚡ Bolt: Prevent O(N) memory bottleneck by doing UNION ALL, pagination and sorting at DB level.
+      const paginatedItems = await unionAll(uiQuery, apiQuery)
+        .orderBy(asc(sql`name`))
+        .limit(limit)
+        .offset(offset);
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
-
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      // Execute separate count queries for pagination metadata
+      const totalUiResult = await db.select({ count: sql<number>`count(*)` }).from(tests).where(and(...uiConditions));
+      const totalApiResult = await db.select({ count: sql<number>`count(*)` }).from(apiTests).where(and(...apiConditions));
+      const totalItems = Number(totalUiResult[0].count) + Number(totalApiResult[0].count);
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 **What:** Replaced the JavaScript array concatenation and `.slice()` operations in the `/api/selectable-tests` endpoint with a database-level `UNION ALL` query using Drizzle ORM's `unionAll` function. Pagination (`LIMIT` and `OFFSET`) and sorting (`ORDER BY`) are now performed directly in PostgreSQL.

🎯 **Why:** The previous implementation fetched all UI and API tests from the database into Node.js memory, sorted the entire combined array, and then sliced it to return the requested page. This caused an $O(N)$ memory bottleneck, where $N$ is the total number of tests in the system. As the test suite grows, this endpoint would consume increasing amounts of memory and CPU time, potentially leading to slow response times or out-of-memory errors on the server.

📊 **Impact:** 
*   Reduces memory overhead from $O(N)$ to $O(1)$ regarding the total data volume.
*   Significantly speeds up the endpoint execution time for large datasets by avoiding full table scans into application memory.
*   Ensures consistent performance regardless of the total number of test suites.

🔬 **Measurement:** 
1.  Navigate to the UI where the TestSuiteSelectorModal is used.
2.  Open the modal.
3.  Observe the network request to `/api/selectable-tests?search=&page=1&limit=X`. 
4.  The request should be fast, and the returned items should be correctly paginated and sorted.
5.  Check the total item counts; they should match the total number of UI and API tests available.

---
*PR created automatically by Jules for task [17676523714670637009](https://jules.google.com/task/17676523714670637009) started by @Markg981*