### PR TITLE
⚡ Bolt: [performance improvement] Optimize selectable-tests API with unionAll pagination

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+## 2024-05-25 - O(N) Array Operations in DB Queries
+**Learning:** When combining results from multiple tables in Express endpoints (e.g., `/api/selectable-tests`), fetching all records into application memory to use `[...results].slice(offset, offset + limit)` introduces severe memory and CPU overhead at scale.
+**Action:** Always leverage `unionAll` from `drizzle-orm/pg-core` to merge the query builders and chain `.limit().offset().orderBy()` to push pagination logic down to the database.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1684,8 +1685,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         apiConditions.push(ilike(apiTests.name, searchPattern));
       }
 
-      // Execute queries
-      const uiTestResults = await db.select({
+      // ⚡ Bolt Optimization: Replace O(N) memory concatenation and slicing with a unified DB query
+      // using unionAll to push pagination and sorting directly to the database layer.
+      const uiQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1697,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,19 +1707,19 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // Separate count query to avoid fetching all data into memory
+      const uiCountQuery = db.select({ count: sql<number>`cast(count(${tests.id}) as integer)` }).from(tests).where(and(...uiConditions));
+      const apiCountQuery = db.select({ count: sql<number>`cast(count(${apiTests.id}) as integer)` }).from(apiTests).where(and(...apiConditions));
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
+      const [uiCountResult, apiCountResult] = await Promise.all([uiCountQuery, apiCountQuery]);
+      const totalItems = (uiCountResult[0]?.count || 0) + (apiCountResult[0]?.count || 0);
 
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      // Paginated unionAll query
+      const paginatedItems = await unionAll(uiQuery, apiQuery)
+        .orderBy(asc(sql`name`))
+        .limit(limit)
+        .offset(offset);
+
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 **What:** Replaced the JavaScript array concatenation (`[...uiTestResults, ...apiTestResults]`) and slicing (`slice(offset, offset + limit)`) in `/api/selectable-tests` with a database-native `unionAll` query that applies `LIMIT`, `OFFSET`, and `ORDER BY` directly at the Postgres layer.

🎯 **Why:** The previous implementation fetched *all* matching UI tests and *all* API tests from the database, transferred them across the network to Node.js, allocated memory for the combined array, sorted it in memory, and then discarded the vast majority of it to return a 10-item page. This introduces severe O(N) memory and compute bottlenecks as user test suites grow.

📊 **Impact:** 
- Reduces Node.js heap memory allocations by ~O(N) for this endpoint.
- Decreases network transfer payload size between DB and the API server by only transmitting the requested 10 items instead of thousands.
- Offloads sorting to the highly optimized Postgres engine.

🔬 **Measurement:**
Load test the `/api/selectable-tests` endpoint using a database seeded with 100,000 mock tests. The application memory footprint will remain flat with this optimization, whereas the previous implementation would likely block the main thread and heavily spike garbage collection overhead.

---
*PR created automatically by Jules for task [10510922443946146071](https://jules.google.com/task/10510922443946146071) started by @Markg981*