### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N) memory pagination with SQL unionAll

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+
+## 2024-05-25 - Prevent O(N) memory scaling for paginated union queries
+**Learning:** Paginating and combining multiple tables (e.g. `tests` and `apiTests`) by fetching all records into node.js arrays, concatenating them (`[...a, ...b]`), sorting in JS, and then slicing creates an O(N) memory/compute bottleneck on the server that crashes as rows scale.
+**Action:** Use Drizzle ORM's `unionAll` (imported from `drizzle-orm/pg-core`) on unawaited queries to perform the combination, counting, `limit()`, `offset()`, and `orderBy()` natively in PostgreSQL/PGlite.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1684,8 +1685,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         apiConditions.push(ilike(apiTests.name, searchPattern));
       }
 
-      // Execute queries
-      const uiTestResults = await db.select({
+      // ⚡ Bolt: Prevent O(N) memory allocation by using unionAll to push pagination down to PostgreSQL
+      const uiTestQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1696,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiTestQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,20 +1706,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      const combinedQuery = unionAll(uiTestQuery, apiTestQuery);
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
-
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      const countResult = await db.select({ count: sql<number>`count(*)` }).from(combinedQuery.as('combined_for_count'));
+      const totalItems = Number(countResult[0]?.count) || 0;
       const totalPages = Math.ceil(totalItems / limit);
+
+      const paginatedItems = await combinedQuery.limit(limit).offset(offset).orderBy(sql`name ASC`);
 
       res.json({
         items: paginatedItems,


### PR DESCRIPTION
💡 What: Replaced an in-memory JS approach (combining, sorting, and slicing arrays on the Node.js server) with Drizzle ORM's `unionAll` to combine `tests` and `apiTests` directly at the database layer. Applied `limit()`, `offset()`, and `orderBy()` natively in SQL.
🎯 Why: The `/api/selectable-tests` endpoint was querying the entire user test suite into JS arrays before slicing for a 10-item page limit. This caused severe O(N) memory degradation and compute bottlenecks as a user's test suite expanded.
📊 Impact: Expected memory usage reduction from O(N) payload sizes to O(1) page payloads (~kb memory vs dynamically scaling mb sizes), reducing Node.js garbage collection pauses and significantly accelerating server response times for large scale testing suites.
🔬 Measurement: Verify memory utilization drops when hitting `/api/selectable-tests?limit=10&page=1` for a user scaling from 100 to 1000 tests. Observe DB query sizes only returning 10 rows per request.

---
*PR created automatically by Jules for task [3024574425042329562](https://jules.google.com/task/3024574425042329562) started by @Markg981*