### PR TITLE
⚡ Bolt: [Optimize selectable tests pagination]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+## 2026-05-29 - [Drizzle ORM Pagination Optimization]
+**Learning:** [Using `unionAll` combined with CTE via `$with` significantly reduces Node.js memory footprint when paginating datasets originating from multiple DB tables (e.g., UI vs API tests) instead of fetching all records into memory first.]
+**Action:** [Always leverage database-level tools like `unionAll` and CTEs for multi-table pagination/sorting and avoid combining and slicing arrays in Node runtime.]

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1685,7 +1686,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Execute queries
-      const uiTestResults = await db.select({
+      const uiTestQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1696,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiTestQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,19 +1706,28 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // Combine queries using unionAll
+      const combinedQuery = unionAll(uiTestQuery, apiTestQuery);
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
+      // Use $with to treat the union as a subquery for pagination and sorting
+      const sq = db.$with('sq').as(combinedQuery);
 
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      // Fetch paginated results directly from DB
+      const paginatedItems = await db
+        .with(sq)
+        .select()
+        .from(sq)
+        .orderBy(asc(sq.name))
+        .limit(limit)
+        .offset(offset);
+
+      // Fetch total count to calculate pagination metadata
+      const countResult = await db
+        .with(sq)
+        .select({ count: sql<number>`count(*)` })
+        .from(sq);
+
+      const totalItems = Number(countResult[0]?.count || 0);
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 **What**: Refactored the `/api/selectable-tests` route to leverage Drizzle ORM's `unionAll` and CTEs (`$with`). This allows the database to handle the combination, sorting, and pagination (limit/offset) of UI and API tests directly via SQL.

🎯 **Why**: Previously, the endpoint fetched *all* UI tests and *all* API tests into Node.js memory. It then combined them into a single massive array, executed an in-memory `.sort()`, and finally extracted a page via `.slice()`. This O(N) memory scaling is a classic backend bottleneck that would inevitably lead to severe latency degradation and potential Node.js out-of-memory (OOM) crashes for users with large test suites.

📊 **Impact**: Reduces Node.js memory overhead for this endpoint from O(N) to O(1) (relative to the user's total test count). Processing time and latency are drastically improved by pushing the sorting and filtering load to the database engine.

🔬 **Measurement**: Verify by creating hundreds or thousands of UI/API tests for a single user and observing the memory footprint and latency of requests to `/api/selectable-tests?page=1&limit=10`. The optimized version should maintain constant memory usage and consistent low response times.

---
*PR created automatically by Jules for task [3855096988535206301](https://jules.google.com/task/3855096988535206301) started by @Markg981*