### PR TITLE
⚡ Bolt: O(1) Memory Pagination via `unionAll` for Selectable Tests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+
+## 2026-05-31 - Pagination with multiple tables using unionAll
+**Learning:** The /api/selectable-tests endpoint was fetching all UI and API tests into Node.js memory arrays, combining them with the spread operator, sorting them in memory, and then manually slicing them for pagination. This O(N) memory allocation and processing causes severe performance bottlenecks for users with many tests.
+**Action:** Use Drizzle ORM's `unionAll` function from `drizzle-orm/pg-core` to combine unawaited queries from different tables. Chain `.limit()`, `.offset()`, and `.orderBy()` directly onto the combined query to push pagination and sorting logic to the database, preventing memory bloat in Node.js.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1685,7 +1686,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Execute queries
-      const uiTestResults = await db.select({
+      const uiTestQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1696,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiTestQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,19 +1706,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // Use unionAll to combine and paginate in the database to prevent O(N) memory bottleneck
+      const paginatedItems = await unionAll(uiTestQuery, apiTestQuery)
+        .orderBy(sql`name asc`)
+        .limit(limit)
+        .offset(offset);
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
+      // Get count using separate queries to avoid full table fetch
+      const [uiCountResult] = await db.select({ count: sql`count(*)` }).from(tests).where(and(...uiConditions));
+      const [apiCountResult] = await db.select({ count: sql`count(*)` }).from(apiTests).where(and(...apiConditions));
 
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      const totalItems = Number(uiCountResult?.count || 0) + Number(apiCountResult?.count || 0);
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 What: Implemented database-level pagination in the `/api/selectable-tests` endpoint using Drizzle ORM's `unionAll` function. Also updated `count` logic to compute the total counts directly in the database.
🎯 Why: The previous implementation fetched all UI and API tests into memory, combined them with spread operators, sorted them with `.sort()`, and used array `.slice()` for pagination. This created an O(N) memory allocation and processing bottleneck, which degraded severely as the number of tests grew.
📊 Impact: Completely eliminates the O(N) memory constraint in Node.js. Sorting and pagination are now delegated to PostgreSQL (or PGLite), drastically reducing request execution times, reducing Node.js memory footprint, and avoiding memory limit crashes for accounts with hundreds or thousands of tests.
🔬 Measurement: To verify, call the `/api/selectable-tests` endpoint with a simulated large dataset. Observe that memory utilization is flat compared to the old approach, and response times are vastly improved. Run `npm run check` and `npm test` to verify API and query logic correctness.

---
*PR created automatically by Jules for task [11408823264492149154](https://jules.google.com/task/11408823264492149154) started by @Markg981*