### PR TITLE
⚡ Bolt: DB-level pagination using unionAll in selectable tests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+
+## 2024-05-18 - PostgreSQL Count Casting in Drizzle ORM
+**Learning:** When performing aggregation queries like `count(*)` using Drizzle ORM with PostgreSQL/PGlite, the returned count value is a string (bigint), not a number. If multiple counts are added together, this results in string concatenation bugs.
+**Action:** Always wrap the aggregated count result with `Number()` (e.g., `Number(countResult.count)`) before performing arithmetic operations.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -45,7 +45,8 @@ import { z } from "zod";
 import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
-import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm";
+import { unionAll } from "drizzle-orm/pg-core"; // Added or, like, ilike, inArray, isNull
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1684,8 +1685,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         apiConditions.push(ilike(apiTests.name, searchPattern));
       }
 
-      // Execute queries
-      const uiTestResults = await db.select({
+      // Build unawaited subqueries
+      const uiQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1696,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,19 +1706,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // ⚡ BOLT OPTIMIZATION: Resolves O(N) memory and compute bottleneck by utilizing
+      // unionAll to push pagination, sorting, and concatenation down to the database level.
+      // This eliminates the need to load all items into memory and manually slice.
+      const paginatedItems = await unionAll(uiQuery, apiQuery)
+        .orderBy(sql`name`)
+        .limit(limit)
+        .offset(offset);
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
-
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      // Get total count using subqueries
+      const [{ count: uiCount }] = await db.select({ count: sql<number>`count(*)` }).from(tests).where(and(...uiConditions));
+      const [{ count: apiCount }] = await db.select({ count: sql<number>`count(*)` }).from(apiTests).where(and(...apiConditions));
+      const totalItems = Number(uiCount) + Number(apiCount);
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 What: Refactored `GET /api/selectable-tests` in `server/routes.ts` to use Drizzle's `unionAll`. This replaces the previous logic which fetched all `uiTests` and `apiTests` into Node.js memory, manually concatenated them, sorted them, and finally sliced them for pagination. Now, pagination, ordering, and concatenation are pushed directly down to the database using `unionAll`.
🎯 Why: Resolves a critical $O(N)$ memory and compute bottleneck. As the number of tests grows, pulling thousands of rows into server memory just to return a page of 10 items causes severe memory consumption, increased API latency, and unnecessary database load.
📊 Impact: Reduces memory usage for this endpoint from $O(N)$ (where $N$ is total tests) to $O(1)$ (constant 10 items). Eliminates the processing overhead of array cloning and sorting on the Node.js event loop, likely reducing endpoint latency by $>80\%$ on large datasets.
🔬 Measurement: Can be verified by creating a large dataset (e.g., 5000+ UI tests and API tests) and benchmarking the `GET /api/selectable-tests?limit=10&page=1` endpoint. The memory profile and response time should remain flat regardless of the total number of tests in the database.

---
*PR created automatically by Jules for task [8865546960249127858](https://jules.google.com/task/8865546960249127858) started by @Markg981*