### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+## 2026-06-13 - Replaced memory pagination with DB unionAll pagination
+**Learning:** The /api/selectable-tests route was fetching all records into memory, concatenating, sorting, and then slicing. This is an O(N) memory bottleneck.
+**Action:** Use Drizzle ORM's unionAll with .limit, .offset, and .orderBy directly at the database level to maintain O(1) memory and improve latency.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1684,8 +1685,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         apiConditions.push(ilike(apiTests.name, searchPattern));
       }
 
-      // Execute queries
-      const uiTestResults = await db.select({
+      // ⚡ BOLT OPTIMIZATION: Replaced O(N) memory concatenation and JS sort with DB-level unionAll, limit, offset, and order by.
+      // This solves an N-scaling memory and performance bottleneck when returning user selectable tests.
+      const uiTestQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1697,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiTestQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,19 +1707,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // Execute union query with pagination and ordering
+      const paginatedItems = await unionAll(uiTestQuery, apiTestQuery)
+        .orderBy(asc(sql`name`))
+        .limit(limit)
+        .offset(offset);
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
+      // Get total count
+      const uiCountResult = await db.select({ count: sql`count(*)` }).from(tests).where(and(...uiConditions));
+      const apiCountResult = await db.select({ count: sql`count(*)` }).from(apiTests).where(and(...apiConditions));
 
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      const totalItems = Number(uiCountResult[0]?.count || 0) + Number(apiCountResult[0]?.count || 0);
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 What: Replaced array concatenation, JS sorting, and array slicing in the `GET /api/selectable-tests` endpoint with a direct `unionAll` database query using `.orderBy()`, `.limit()`, and `.offset()`. Count is now calculated individually via `COUNT(*)` rather than fetching all rows.

🎯 Why: The previous implementation fetched all user UI and API test records from the database into a Node.js process array, sorted them, and then paginated the list. As the number of tests scales into the thousands, this creates an O(N) memory constraint and massive latency spike on every request due to over-fetching.

📊 Impact: Reduces the route's Node.js memory overhead per request from O(N) down to O(1), and vastly speeds up the DB execution time since it only returns the precise paginated rows (`10` by default).

🔬 Measurement: Verify via any load testing or performance profiling on `GET /api/selectable-tests?page=1&limit=10` with a populated database. Check `server/routes.ts` code to confirm the O(N) array concatenation was removed in favor of Drizzle ORM `.limit` logic on a `.unionAll()` query.

---
*PR created automatically by Jules for task [11947889889789157154](https://jules.google.com/task/11947889889789157154) started by @Markg981*