### PR TITLE
⚡ Bolt: Consolidate redundant O(K*N) array passes in reporting endpoints

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+## 2024-05-25 - O(K*N) Array Passes in Report Generation
+**Learning:** The reporting API endpoints were creating multiple intermediate arrays by chaining `.filter()` and `.map()`, and running multiple independent `.forEach()` loops over large result sets. This resulted in O(K*N) CPU operations and excessive memory allocations which is a bottleneck on endpoints fetching aggregated data.
+**Action:** Consolidate multiple sequential array iterations and aggregations into a single `for...of` O(N) pass to minimize CPU cycles and eliminate temporary array memory footprints.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1800,67 +1800,30 @@ app.get("/api/test-plan-executions/:executionId/report", async (req, res) => {
 
     // 3. Calculate Key Metrics
     const totalTests = testCaseResults.length;
-    const passedTests = testCaseResults.filter(r => r.status === 'Passed').length;
-    const failedTests = testCaseResults.filter(r => r.status === 'Failed').length;
-    const skippedTests = testCaseResults.filter(r => r.status === 'Skipped').length;
-    // Add other statuses if needed (e.g., 'Error', 'Pending')
-
+    let passedTests = 0;
+    let failedTests = 0;
+    let skippedTests = 0;
     let totalDurationMs = 0;
-    testCaseResults.forEach(r => {
-      if (r.durationMs !== null && r.durationMs !== undefined) {
-        totalDurationMs += r.durationMs;
-      }
-    });
-    const averageTimePerTest = totalTests > 0 ? Math.round(totalDurationMs / totalTests) : 0;
 
     // 4. Prepare data for charts
-    const passFailSkippedDistribution = {
-      passed: passedTests,
-      failed: failedTests,
-      skipped: skippedTests,
-    };
-
     const priorityDistribution: Record<string, { passed: number, failed: number, skipped: number, total: number }> = {};
-    testCaseResults.forEach(r => {
-      const prio = r.priority || 'N/A';
-      if (!priorityDistribution[prio]) {
-        priorityDistribution[prio] = { passed: 0, failed: 0, skipped: 0, total: 0 };
-      }
-      priorityDistribution[prio].total++;
-      if (r.status === 'Passed') priorityDistribution[prio].passed++;
-      else if (r.status === 'Failed') priorityDistribution[prio].failed++;
-      else if (r.status === 'Skipped') priorityDistribution[prio].skipped++;
-    });
-
     const detailedSeverityDistribution: Record<string, { passed: number, failed: number, skipped: number, total: number }> = {};
-     testCaseResults.forEach(r => {
-      const sev = r.severity || 'N/A';
-      if (!detailedSeverityDistribution[sev]) {
-        detailedSeverityDistribution[sev] = { passed: 0, failed: 0, skipped: 0, total: 0 };
-      }
-      detailedSeverityDistribution[sev].total++;
-      if (r.status === 'Passed') detailedSeverityDistribution[sev].passed++;
-      else if (r.status === 'Failed') detailedSeverityDistribution[sev].failed++;
-      else if (r.status === 'Skipped') detailedSeverityDistribution[sev].skipped++;
-    });
 
     // 5. Detailed View of Failed Tests
-    const failedTestDetails = testCaseResults
-      .filter(r => r.status === 'Failed')
-      .map(r => ({
-        id: r.id,
-        testName: r.testName,
-        reasonForFailure: r.reasonForFailure,
-        screenshotUrl: r.screenshotUrl,
-        detailedLog: r.detailedLog,
-        component: r.component,
-        priority: r.priority,
-        severity: r.severity,
-        durationMs: r.durationMs,
-        uiTestId: r.uiTestId,
-        apiTestId: r.apiTestId,
-        testType: r.testType,
-      }));
+    const failedTestDetails: Array<{
+        id: string;
+        testName: string;
+        reasonForFailure: string | null;
+        screenshotUrl: string | null;
+        detailedLog: string | null;
+        component: string | null;
+        priority: string | null;
+        severity: string | null;
+        durationMs: number | null;
+        uiTestId: number | null;
+        apiTestId: number | null;
+        testType: string | null;
+    }> = [];
 
     // 6. Expandable Test Groupings (by module, then by component as an example)
     const groupedByModule: Record<string, {
@@ -1871,7 +1834,51 @@ app.get("/api/test-plan-executions/:executionId/report", async (req, res) => {
         }>
     }> = {};
 
-    testCaseResults.forEach(r => {
+    // ⚡ Bolt: Single O(N) pass to aggregate all test result metrics, eliminating multiple O(N) iterations
+    for (const r of testCaseResults) {
+      // 3. Status Counts & Duration
+      if (r.status === 'Passed') passedTests++;
+      else if (r.status === 'Failed') failedTests++;
+      else if (r.status === 'Skipped') skippedTests++;
+
+      if (r.durationMs !== null && r.durationMs !== undefined) {
+        totalDurationMs += r.durationMs;
+      }
+
+      // 4. Distribution Data
+      const prio = r.priority || 'N/A';
+      if (!priorityDistribution[prio]) priorityDistribution[prio] = { passed: 0, failed: 0, skipped: 0, total: 0 };
+      priorityDistribution[prio].total++;
+      if (r.status === 'Passed') priorityDistribution[prio].passed++;
+      else if (r.status === 'Failed') priorityDistribution[prio].failed++;
+      else if (r.status === 'Skipped') priorityDistribution[prio].skipped++;
+
+      const sev = r.severity || 'N/A';
+      if (!detailedSeverityDistribution[sev]) detailedSeverityDistribution[sev] = { passed: 0, failed: 0, skipped: 0, total: 0 };
+      detailedSeverityDistribution[sev].total++;
+      if (r.status === 'Passed') detailedSeverityDistribution[sev].passed++;
+      else if (r.status === 'Failed') detailedSeverityDistribution[sev].failed++;
+      else if (r.status === 'Skipped') detailedSeverityDistribution[sev].skipped++;
+
+      // 5. Failed Details
+      if (r.status === 'Failed') {
+        failedTestDetails.push({
+          id: r.id,
+          testName: r.testName,
+          reasonForFailure: r.reasonForFailure,
+          screenshotUrl: r.screenshotUrl,
+          detailedLog: r.detailedLog,
+          component: r.component,
+          priority: r.priority,
+          severity: r.severity,
+          durationMs: r.durationMs,
+          uiTestId: r.uiTestId,
+          apiTestId: r.apiTestId,
+          testType: r.testType,
+        });
+      }
+
+      // 6. Groupings
       const moduleName = r.module || 'Uncategorized Module';
       const componentName = r.component || 'Uncategorized Component';
 
@@ -1896,7 +1903,14 @@ app.get("/api/test-plan-executions/:executionId/report", async (req, res) => {
         groupedByModule[moduleName].skipped++;
         groupedByModule[moduleName].components[componentName].skipped++;
       }
-    });
+    }
+
+    const averageTimePerTest = totalTests > 0 ? Math.round(totalDurationMs / totalTests) : 0;
+    const passFailSkippedDistribution = {
+      passed: passedTests,
+      failed: failedTests,
+      skipped: skippedTests,
+    };
 
     const reportData = {
       header: {

--- a/server/test-execution-service.ts
+++ b/server/test-execution-service.ts
@@ -445,9 +445,19 @@ export async function processTestPlanJob(
     .where(eq(reportTestCaseResultsTable.testPlanExecutionId, testPlanRunId));
 
   const calculatedTotalTests = finalDetailedResults.length;
-  const calculatedPassedTests = finalDetailedResults.filter((r: any) => r.status === 'Passed').length;
-  const calculatedFailedTests = finalDetailedResults.filter((r: any) => r.status === 'Failed').length;
-  const calculatedSkippedTests = finalDetailedResults.filter((r: any) => r.status === 'Skipped').length;
+  let calculatedPassedTests = 0;
+  let calculatedFailedTests = 0;
+  let calculatedSkippedTests = 0;
+  let hasError = false;
+
+  // ⚡ Bolt: Replace multiple .filter() and .some() passes with a single O(N) loop
+  for (const r of finalDetailedResults) {
+    if (r.status === 'Passed') calculatedPassedTests++;
+    else if (r.status === 'Failed') calculatedFailedTests++;
+    else if (r.status === 'Skipped') calculatedSkippedTests++;
+    else if (r.status === 'Error') hasError = true;
+  }
+
   // Consider 'Error' status as failures or a separate category if needed for overall status.
   // For overall status, let's say if any 'Failed' or 'Error', the whole run is 'failed'.
   // If any 'Skipped' and no 'Failed'/'Error', maybe 'partial' or 'completed_with_skipped'.
@@ -456,7 +466,7 @@ export async function processTestPlanJob(
   let finalOverallStatus: TestPlanExecution['status'] = 'pending'; // Should be 'completed' or 'failed' or 'error'
   if (calculatedTotalTests === 0 && selectedTestsLinks.length > 0) {
     finalOverallStatus = 'error'; // No results recorded but tests were expected
-  } else if (calculatedFailedTests > 0 || finalDetailedResults.some((r: any) => r.status === 'Error')) {
+  } else if (calculatedFailedTests > 0 || hasError) {
     finalOverallStatus = 'failed';
   } else if (calculatedTotalTests === calculatedPassedTests && calculatedTotalTests > 0) {
     finalOverallStatus = 'completed';


### PR DESCRIPTION
### 💡 What
Refactored multiple separate array passes in `server/routes.ts` and `server/test-execution-service.ts` into single O(N) `for...of` loops.

### 🎯 Why
The codebase was iterating over `testCaseResults` arrays multiple times (up to 8 times in `server/routes.ts` and 4 times in `test-execution-service.ts`) using combinations of `.filter()`, `.map()`, and `.forEach()`. This created an O(K*N) bottleneck and allocated numerous intermediate arrays in memory, causing performance degradation as the number of test results scales up.

### 📊 Impact
Reduces CPU cycles and array processing overhead significantly for endpoints calculating execution aggregates. It completely eliminates intermediate array garbage collection spikes by replacing multiple filtering iterations with straightforward counter accumulations.

### 🔬 Measurement
Verify the changes by analyzing CPU usage and response times of the `/api/test-plan-executions/:id/report` endpoint under heavy load (with thousands of test case results). Ensure `npm run test` continues to pass, validating that logic identicality has been preserved.

---
*PR created automatically by Jules for task [12227833489368511945](https://jules.google.com/task/12227833489368511945) started by @Markg981*