### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - N+1 Query in Test Plan Execution
 **Learning:** The `runTestPlan` function in `server/test-execution-service.ts` was executing a separate DB query for each UI/API test inside the sequential execution loop, causing an N+1 query bottleneck.
 **Action:** Always batch fetch related models using `inArray` and store them in O(1) memory lookup maps (e.g., `new Map()`) prior to looping when querying associations inside loops using Drizzle ORM.
+## 2024-05-24 - Node.js Memory Exhaustion on Selectable Tests
+**Learning:** The `/api/selectable-tests` endpoint was querying all matching UI and API tests into memory, concatenating them, and performing an O(N log N) in-memory array sort before paginating. This causes a severe memory and CPU bottleneck for users with large test suites.
+**Action:** Use Drizzle ORM's `unionAll()` with `.as('alias')` to combine queries across tables and apply `.orderBy()`, `.limit()`, and `.offset()` at the database level to drastically reduce backend memory consumption and payload transfer time.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { v4 as uuidv4 } from 'uuid'; // For generating IDs
 import { createInsertSchema } from 'drizzle-zod';
 import { db } from "./db";
 import { eq, and, desc, sql, getTableColumns, asc, or, like, ilike, inArray, isNull } from "drizzle-orm"; // Added or, like, ilike, inArray, isNull
+import { unionAll } from "drizzle-orm/pg-core";
 import { playwrightService } from "./playwright-service";
 import type { Logger as WinstonLogger } from 'winston';
 import schedulerService from "./scheduler-service"; // Import schedulerService
@@ -1685,7 +1686,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Execute queries
-      const uiTestResults = await db.select({
+      const uiTestQuery = db.select({
           id: tests.id,
           name: tests.name,
           description: sql<string>`null`.as('description'),
@@ -1695,7 +1696,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(tests)
         .where(and(...uiConditions));
 
-      const apiTestResults = await db.select({
+      const apiTestQuery = db.select({
           id: apiTests.id,
           name: apiTests.name,
           description: sql<string>`null`.as('description'),
@@ -1705,19 +1706,19 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .from(apiTests)
         .where(and(...apiConditions));
 
-      // Combine results
-      let combinedResults = [...uiTestResults, ...apiTestResults];
+      // Combine results using unionAll and push pagination/sorting to DB
+      const combinedUnion = unionAll(uiTestQuery, apiTestQuery).as('combined_union');
 
-      // Sort combined results (e.g., by name or updatedAt)
-      combinedResults.sort((a, b) => {
-        // Sort by name alphabetically by default
-        return a.name.localeCompare(b.name);
-        // Or sort by updatedAt if preferred:
-        // return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
+      const paginatedItems = await db.select()
+        .from(combinedUnion)
+        .orderBy(asc(sql`name`))
+        .limit(limit)
+        .offset(offset);
 
-      const totalItems = combinedResults.length;
-      const paginatedItems = combinedResults.slice(offset, offset + limit);
+      const totalItemsResult = await db.select({ count: sql`count(*)` })
+        .from(combinedUnion);
+      const totalItems = Number(totalItemsResult[0]?.count) || 0;
+
       const totalPages = Math.ceil(totalItems / limit);
 
       res.json({


### PR DESCRIPTION
💡 **What**: Refactored the `GET /api/selectable-tests` endpoint to utilize Drizzle ORM's `unionAll` instead of fetching all matching records into Node.js memory. Sorting (`.orderBy`), and pagination (`.limit` and `.offset`) are now processed directly at the database level.
🎯 **Why**: Previously, the endpoint fetched all matching UI and API tests, combined the arrays, sorted them in JavaScript, and then sliced them for pagination. For large sets of tests (e.g. thousands), this caused an $O(N)$ memory bottleneck and an $O(N \log N)$ sort latency penalty in Node.js. Pushing this workload to PostgreSQL handles it efficiently.
📊 **Impact**: Reduces backend memory consumption to near zero (only fetched records are loaded) and eliminates the CPU bottleneck of JS sorting. The API response time for large datasets should drop significantly (e.g. going from hundreds of milliseconds down to ~10-20ms).
🔬 **Measurement**: Inspect the memory usage on backend instances when querying `GET /api/selectable-tests` with empty search parameters over thousands of tests, and verify correct pagination and alphabetical sorting.

---
*PR created automatically by Jules for task [14792634990825093434](https://jules.google.com/task/14792634990825093434) started by @Markg981*