### PR TITLE
fix(ui): dark-mode fixes for API Tester editors and the Create Test c…

### DIFF
--- a/client/src/components/visual-builder/VisualTestBuilder.tsx
+++ b/client/src/components/visual-builder/VisualTestBuilder.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { 
-  ReactFlow, 
-  Background, 
-  Controls, 
-  MiniMap,
+  ReactFlow,
+  Background,
   Node,
   Edge,
   addEdge,
@@ -163,10 +161,9 @@ export function VisualTestBuilder({
           connectionMode={ConnectionMode.Strict}
           fitView
           className="bg-dot-pattern"
+          proOptions={{ hideAttribution: true }}
         >
-          <Background color="#9ca3af" gap={16} />
-          <Controls />
-          <MiniMap zoomable pannable nodeColor="#3b82f6" />
+          <Background color="hsl(var(--border))" gap={16} />
         </ReactFlow>
       </div>
 

--- a/client/src/hooks/use-is-dark.ts
+++ b/client/src/hooks/use-is-dark.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Whether the app is in dark mode, tracked from the `dark` class on <html>.
+ * The app drives theming via that class (SettingsEffectLoader + the topbar toggle),
+ * not via a next-themes provider — so components that need the theme (e.g. Monaco
+ * editors) must read it from here, reactively.
+ */
+export function useIsDark(): boolean {
+  const [isDark, setIsDark] = useState(
+    () => typeof document !== 'undefined' && document.documentElement.classList.contains('dark'),
+  );
+
+  useEffect(() => {
+    const el = document.documentElement;
+    const update = () => setIsDark(el.classList.contains('dark'));
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(el, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark;
+}

--- a/client/src/pages/ApiTesterPage.tsx
+++ b/client/src/pages/ApiTesterPage.tsx
@@ -20,7 +20,7 @@ import { apiRequest } from '@/lib/queryClient';
 import { toast } from '@/hooks/use-toast';
 import Editor from '@monaco-editor/react';
 import { Checkbox } from "@/components/ui/checkbox";
-import { useTheme } from "next-themes";
+import { useIsDark } from "@/hooks/use-is-dark";
 import { HistoryPanel } from '@/components/api-tester/HistoryPanel';
 import { SavedTestsPanel } from '@/components/api-tester/SavedTestsPanel';
 import { SaveApiTestModal } from '@/components/api-tester/SaveApiTestModal';
@@ -72,7 +72,7 @@ interface FormDataField {
 
 const ApiTesterPage: React.FC = () => {
   const { t } = useTranslation();
-  const { theme } = useTheme();
+  const isDark = useIsDark();
   const [method, setMethod] = useState<string>(httpMethods[0]);
   const [url, setUrl] = useState<string>('');
   const [requestBodyValue, setRequestBodyValue] = useState<string>('');
@@ -462,7 +462,7 @@ const ApiTesterPage: React.FC = () => {
     });
   };
 
-  const monacoTheme = theme === 'dark' || theme === 'system' ? 'vs-dark' : 'light';
+  const monacoTheme = isDark ? 'vs-dark' : 'light';
 
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [currentTestToEdit, setCurrentTestToEdit] = useState<ApiTest | null>(null);


### PR DESCRIPTION
…anvas

- API Tester: the Monaco request/response editors read the theme from next-themes' useTheme, but the app has no next-themes provider (theming is the `dark` class on <html>), so `theme` was always undefined and the editors stayed light — two white boxes in dark mode. Added a useIsDark() hook that tracks the class reactively; Monaco now switches to vs-dark.
- Create Test (VisualTestBuilder / React Flow): removed the minimap (a hardcoded white 200×150 box that also captured confusing pan/zoom), the zoom Controls, and the reactflow.dev attribution link — none belong in a linear test-step builder. The canvas background dots now use a token color.