### PR TITLE
fix(create-test): make UI test authoring against SPA sites actually work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ scripts/netcontent/endpoints.manifest.json
 scripts/netcontent-ui/views.inventory.json
 
 scripts/netcontent-ui/ui-tests.preview.json
+
+# Playwright MCP session artifacts
+.playwright-mcp/

--- a/client/src/components/draggable-element.tsx
+++ b/client/src/components/draggable-element.tsx
@@ -26,13 +26,17 @@ interface DraggableElementProps {
 
 export function DraggableElement({ element, onHover }: DraggableElementProps) {
   const { t } = useTranslation();
+  // `element` MUST be in the deps array: detected-element ids are positional
+  // (regenerated from 0 on every detect), so React reuses the same DraggableElement
+  // instance for a different element after a re-detect. Without deps, useDrag keeps the
+  // stale item from first render and the wrong element gets bound to the step.
   const [{ isDragging }, drag] = useDrag(() => ({
     type: "element",
     item: { id: element.id, type: "element", data: element },
     collect: (monitor) => ({
       isDragging: !!monitor.isDragging(),
     }),
-  }));
+  }), [element]);
 
   const renderElementIcon = (type: string) => {
     const iconProps = { className: "h-4 w-4 text-muted-foreground" };

--- a/client/src/components/visual-builder/TestNode.tsx
+++ b/client/src/components/visual-builder/TestNode.tsx
@@ -1,4 +1,5 @@
 import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import { useDrop } from 'react-dnd';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -15,14 +16,31 @@ export type TestNodeData = {
   isRecordingActive?: boolean;
   onUpdateValue: (id: string, value: string) => void;
   onDeleteNode: (id: string) => void;
+  onSetTarget?: (id: string, element: DetectedElement) => void;
   [key: string]: unknown; // Satisfy Record<string, unknown> constraint
 };
 
 export function TestNode({ id, data }: NodeProps<Node<TestNodeData>>) {
   const { t } = useTranslation();
-  
+
   const needsValue = ["input", "wait", "assert", "select", "assertTextContains", "assertElementCount"].includes(data.action.id);
   const needsTarget = ["click", "input", "assert", "hover", "select", "assertTextContains", "assertElementCount"].includes(data.action.id);
+
+  // Accept a detected element dropped from the "Detected Elements" panel and bind it as
+  // this step's target. Without this drop target the dragged element had nowhere to land
+  // and react-dnd snapped it back (it appeared to "vanish").
+  const [{ isOver, canDrop }, dropRef] = useDrop(() => ({
+    accept: "element",
+    canDrop: () => !data.isRecordingActive,
+    drop: (item: { data: DetectedElement }) => {
+      if (data.isRecordingActive) return;
+      data.onSetTarget?.(id, item.data);
+    },
+    collect: (monitor) => ({
+      isOver: !!monitor.isOver(),
+      canDrop: !!monitor.canDrop(),
+    }),
+  }), [id, data.isRecordingActive, data.onSetTarget]);
 
   return (
     <Card className={`min-w-[250px] p-4 shadow-lg border-2 ${data.targetElement ? 'border-primary' : (needsTarget ? 'border-destructive/50' : 'border-border')} bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/75 transition-all`}>
@@ -49,8 +67,17 @@ export function TestNode({ id, data }: NodeProps<Node<TestNodeData>>) {
 
       <div className="space-y-3 mt-4">
         {needsTarget && (
-          <div className="flex items-center space-x-2 bg-muted/50 p-2 rounded-md border border-border/50">
-            <Link2 className={`h-4 w-4 ${data.targetElement ? 'text-green-500' : 'text-muted-foreground'}`} />
+          <div
+            ref={dropRef as any}
+            className={`nodrag flex items-center space-x-2 p-2 rounded-md border transition-colors ${
+              isOver && canDrop
+                ? 'bg-primary/10 border-primary border-dashed'
+                : data.targetElement
+                  ? 'bg-muted/50 border-primary/40'
+                  : 'bg-muted/50 border-destructive/40 border-dashed'
+            }`}
+          >
+            <Link2 className={`h-4 w-4 shrink-0 ${data.targetElement ? 'text-green-500' : 'text-muted-foreground'}`} />
             <span className="text-xs truncate max-w-[180px]">
               {data.targetElement ? data.targetElement.text : t('dashboardPage.dropActionsPrompt')}
             </span>

--- a/client/src/components/visual-builder/VisualTestBuilder.tsx
+++ b/client/src/components/visual-builder/VisualTestBuilder.tsx
@@ -15,7 +15,7 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 
-import { TestStep } from '@/components/drag-drop-provider';
+import { TestStep, DetectedElement } from '@/components/drag-drop-provider';
 import { TestNode, TestNodeData } from './TestNode';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
@@ -67,7 +67,8 @@ export function VisualTestBuilder({
         targetElement: step.targetElement,
         isRecordingActive,
         onUpdateValue: (id, val) => handleUpdateValue(id, val),
-        onDeleteNode: (id) => handleDeleteNode(id)
+        onDeleteNode: (id) => handleDeleteNode(id),
+        onSetTarget: (id, element) => handleSetTarget(id, element)
       }
     }));
 
@@ -136,6 +137,11 @@ export function VisualTestBuilder({
 
   const handleDeleteNode = (id: string) => {
     const updated = testSequence.filter(s => s.id !== id);
+    onUpdateSequence(updated);
+  };
+
+  const handleSetTarget = (id: string, element: DetectedElement) => {
+    const updated = testSequence.map(s => s.id === id ? { ...s, targetElement: element } : s);
     onUpdateSequence(updated);
   };
 

--- a/client/src/pages/dashboard-page-new.tsx
+++ b/client/src/pages/dashboard-page-new.tsx
@@ -1035,47 +1035,19 @@ export default function DashboardPage() {
   const handleSequenceUpdated = (newSequence: DragDropTestStep[]) => {
     setTestSequence(newSequence);
 
-    const allStepsComplete = newSequence.every(isTestStepComplete);
-    console.log("[DashboardPage] handleSequenceUpdated: allStepsComplete:", allStepsComplete, "for newSequence with length:", newSequence.length);
+    // Tests run ONLY when the user clicks "Execute Test". Editing the sequence — adding
+    // an action or binding a target element — must never launch a run on its own.
+    // (Previously, completing every step auto-triggered a debounced Playwright execution,
+    // which surprised users mid-edit and swapped the builder into playback view.)
+    if (typeof debouncedExecuteMutation.cancel === 'function') {
+      debouncedExecuteMutation.cancel();
+    }
 
-    if (newSequence.length > 0 && allStepsComplete && currentUrl && websiteLoaded) {
-      // Conditions for debounced execution (isPending, isExecutingPlayback) are checked inside debouncedExecuteMutation
-      const payload = {
-        url: currentUrl,
-        sequence: newSequence,
-        elements: detectedElements, // Pass current elements as context
-        name: testName || t('dashboardPageNew.toasts.realtimePreviewName', { url: currentUrl || t('dashboardPageNew.toasts.untitled') })
-      };
-      console.log("[DashboardPage] handleSequenceUpdated: Debouncing execution with payload:", payload);
-      debouncedExecuteMutation(payload);
-    } else if (newSequence.length === 0) {
-      // If sequence is cleared, cancel any pending debounced execution
-      if (typeof debouncedExecuteMutation.cancel === 'function') {
-        debouncedExecuteMutation.cancel();
-      }
-      // Also, if sequence is cleared, and a URL is loaded, re-detect elements for the base page.
-      // This resets the element list to the state of the page before any actions.
-      if (currentUrl && websiteLoaded) {
-        // handleDetectElements(); // This would fetch fresh elements.
-        // For now, let's clear detected elements or leave them as is.
-        // setDetectedElements([]);
-      }
-      // If the sequence is empty, ensure playback stops and clears.
+    // If the sequence was cleared, make sure any in-progress playback stops and resets.
+    if (newSequence.length === 0) {
       setIsExecutingPlayback(false);
       setCurrentPlaybackStepIndex(null);
       setPlaybackSteps([]);
-      // Potentially clear the screenshot or revert to initial loaded screenshot
-      // if (loadWebsiteMutation.data?.screenshot) {
-      //  setWebsiteScreenshot(loadWebsiteMutation.data.screenshot);
-      // }
-    } else if (newSequence.length > 0 && !allStepsComplete) {
-      // Sequence is not empty but not all steps are complete.
-      // Cancel any pending debounced execution because the current sequence isn't fully valid for preview.
-      if (typeof debouncedExecuteMutation.cancel === 'function') {
-        debouncedExecuteMutation.cancel();
-      }
-      console.log("Real-time execution skipped: Not all test steps are complete.");
-      // Optionally, provide feedback to the user here (e.g., via a toast or UI indicator)
     }
   };
 

--- a/server/playwright-service.ts
+++ b/server/playwright-service.ts
@@ -15,7 +15,7 @@ import { allowsSelfSignedCertificate, substituteVariables } from './outbound-htt
 const DEFAULT_BROWSER: 'chromium' | 'firefox' | 'webkit' = 'chromium';
 const DEFAULT_HEADLESS = true;
 const DEFAULT_TIMEOUT = 30000;
-const DEFAULT_WAIT_TIME = 1000;
+const DEFAULT_WAIT_TIME = 2000;
 
 let resolvedLogger: WinstonLogger;
 (async () => {
@@ -362,6 +362,13 @@ export class PlaywrightService {
         // timeout is already set by setDefaultTimeout
       });
 
+      // SPA frameworks (Angular/DevExpress, React, …) render their content after
+      // domcontentloaded, so a fixed short wait captures an empty shell. Wait for the
+      // network to go idle first; if it never settles (long-polling/websockets), fall
+      // back to the fixed wait rather than failing.
+      await page.waitForLoadState('networkidle', { timeout: pageTimeout }).catch(() => {
+        resolvedLogger.debug({ message: "PS:loadWebsite - networkidle not reached, proceeding after fixed wait", url });
+      });
       await page.waitForTimeout(effectiveWaitTime);
 
       const html = await page.content();
@@ -613,6 +620,100 @@ export class PlaywrightService {
     return { success: true, actions: [...session.actions] };
   }
 
+  /**
+   * Scans the current page for interactive elements and returns them with GUARANTEED
+   * unique CSS selectors (id → stable attribute → non-transient class combo → nth-of-type
+   * structural path). Single source of truth for element detection — used by both
+   * detectElements() and the post-run detection inside executeAdhocSequence(), so the two
+   * never drift apart (previously they did: execution produced non-unique class selectors
+   * like `button.mat-mdc-menu-item`, which Playwright could not click unambiguously).
+   */
+  private async detectElementsOnPage(page: Page): Promise<DetectedElement[]> {
+    return await page.evaluate(() => {
+      // esbuild/tsx (keepNames) wraps named functions in `__name(fn, "…")`; that helper only
+      // exists in the Node bundle, so provide a harmless identity shim for the browser page.
+      (globalThis as any).__name = (globalThis as any).__name || ((fn: any) => fn);
+
+      const interactiveSelectors = ['input:not([type="hidden"])', 'button', 'a[href]', 'select', 'textarea', '[onclick]', '[role="button"]', '[tabindex]:not([tabindex="-1"])', 'h1, h2, h3, h4, h5, h6', 'img[alt]', 'form', '[data-testid]', '[data-test]'];
+
+      const isUnique = (sel: string) => {
+        try { return document.querySelectorAll(sel).length === 1; } catch { return false; }
+      };
+
+      const structuralPath = (el: Element): string => {
+        const parts: string[] = [];
+        let node: Element | null = el;
+        while (node && node.nodeType === 1 && node.tagName.toLowerCase() !== 'html') {
+          if (node.id && isUnique(`#${CSS.escape(node.id)}`)) { parts.unshift(`#${CSS.escape(node.id)}`); break; }
+          let part = node.tagName.toLowerCase();
+          const parent: Element | null = node.parentElement;
+          if (parent) {
+            const sameTag = Array.from(parent.children).filter((c) => c.tagName === node!.tagName);
+            if (sameTag.length > 1) part += `:nth-of-type(${sameTag.indexOf(node) + 1})`;
+          }
+          parts.unshift(part);
+          node = parent;
+        }
+        return parts.join(' > ');
+      };
+
+      const buildUniqueSelector = (el: Element): string => {
+        const tag = el.tagName.toLowerCase();
+        if (el.id && isUnique(`#${CSS.escape(el.id)}`)) return `#${CSS.escape(el.id)}`;
+        for (const attr of ['data-testid', 'data-test', 'name', 'aria-label']) {
+          const v = el.getAttribute(attr);
+          if (v) { const s = `${tag}[${attr}="${v.replace(/"/g, '\\"')}"]`; if (isUnique(s)) return s; }
+        }
+        if (typeof el.className === 'string' && el.className.trim()) {
+          const classes = el.className.split(/\s+/).filter((c) =>
+            c && !/[:()[\]/.]/.test(c) && !/^(ng|cdk)-/.test(c) && !/(focus|active|hover|selected|touched|dirty|pristine)/i.test(c));
+          for (let n = classes.length; n >= 1; n--) {
+            const s = `${tag}.${classes.slice(0, n).join('.')}`;
+            if (isUnique(s)) return s;
+          }
+        }
+        return structuralPath(el);
+      };
+
+      const detectedElements: any[] = [];
+      const seen = new Set<Element>();
+      let globalElementCounter = 0;
+      interactiveSelectors.forEach((selector) => {
+        document.querySelectorAll(selector).forEach((element, index) => {
+          if (seen.has(element)) return; // an element can match several selectors — keep one entry
+          const rect = element.getBoundingClientRect();
+          if (rect.width > 0 && rect.height > 0 && rect.top >= 0) {
+            seen.add(element);
+            const tagName = element.tagName.toLowerCase();
+            const text = element.textContent?.trim() || '';
+            const placeholder = element.getAttribute('placeholder') || '';
+            const displayText = text || placeholder || element.getAttribute('alt') || `${tagName}-${index}`;
+            const uniqueSelector = buildUniqueSelector(element);
+            let elementType = 'element';
+            if (tagName === 'input') elementType = element.getAttribute('type') || 'input';
+            else if (tagName === 'button' || element.getAttribute('role') === 'button') elementType = 'button';
+            else if (tagName === 'a') elementType = 'link';
+            else if (tagName.match(/h[1-6]/)) elementType = 'heading';
+            else if (tagName === 'select') elementType = 'select';
+            else if (tagName === 'textarea') elementType = 'textarea';
+            const attributes: Record<string, string> = {};
+            Array.from(element.attributes).forEach((attr: any) => { attributes[attr.name] = attr.value; });
+            detectedElements.push({
+              id: `elem-${tagName}-${globalElementCounter++}`,
+              type: elementType,
+              selector: uniqueSelector,
+              text: displayText.substring(0, 100),
+              tag: tagName,
+              attributes,
+              boundingBox: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) },
+            });
+          }
+        });
+      });
+      return detectedElements.slice(0, 50) as DetectedElement[];
+    });
+  }
+
   async executeAdhocSequence(payload: AdhocSequencePayload, userId: number): Promise<{ success: boolean; steps?: StepResult[]; error?: string; duration?: number; detectedElements?: DetectedElement[] }> {
     const testName = payload.name || "Ad-hoc Test";
     resolvedLogger.http({ message: "PlaywrightService: executeAdhocSequence called", testName, userId, url: payload.url });
@@ -695,12 +796,7 @@ export class PlaywrightService {
           if (page && !page.isClosed()) {
             resolvedLogger.debug({ message: "PS:executeAdhocSequence - Attempting element detection (due to navigation failure)", testName, pageClosed: page?.isClosed() });
             try {
-              finalDetectedElementsNavFail = await page.evaluate(() => { // Code for element detection (omitted for brevity, same as original)
-                const interactiveSelectors = ['input:not([type="hidden"])', 'button', 'a[href]', 'select', 'textarea', '[onclick]', '[role="button"]', '[tabindex]:not([tabindex="-1"])', 'h1, h2, h3, h4, h5, h6', 'img[alt]', 'form', '[data-testid]', '[data-test]'];
-                const detectedElementsEval: any[] = []; let globalElementCounter = 0;
-                interactiveSelectors.forEach(selector => { document.querySelectorAll(selector).forEach((element, index) => { const rect = element.getBoundingClientRect(); if (rect.width > 0 && rect.height > 0 && rect.top >= 0) { const tagName = element.tagName.toLowerCase(); const text = element.textContent?.trim() || ''; const placeholder = element.getAttribute('placeholder') || ''; const displayText = text || placeholder || element.getAttribute('alt') || `${tagName}-${index}`; let uniqueSelector = selector; if (element.id) { uniqueSelector = `#${element.id}`; } else if (element.className && typeof element.className === 'string') { const classes = element.className.split(' ').filter(c => c.length > 0 && !c.includes(':') && !c.includes('(') && !c.includes(')')); if (classes.length > 0) uniqueSelector = `${tagName}.${classes[0]}`; } let elementType = 'element'; if (tagName === 'input') elementType = element.getAttribute('type') || 'input'; else if (tagName === 'button' || element.getAttribute('role') === 'button') elementType = 'button'; else if (tagName === 'a') elementType = 'link'; else if (tagName.match(/h[1-6]/)) elementType = 'heading'; else if (tagName === 'select') elementType = 'select'; else if (tagName === 'textarea') elementType = 'textarea'; const attributes: Record<string, string> = {}; Array.from(element.attributes).forEach((attr: any) => { attributes[attr.name] = attr.value; }); detectedElementsEval.push({ id: `elem-${tagName}-${globalElementCounter++}`, type: elementType, selector: uniqueSelector, text: displayText.substring(0, 100), tag: tagName, attributes, boundingBox: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) } }); } }); });
-                return detectedElementsEval.slice(0, 50);
-              });
+              finalDetectedElementsNavFail = await this.detectElementsOnPage(page);
             } catch (detectionError: any) {
               resolvedLogger.warn({ message: `PS:executeAdhocSequence - Error during element detection (navigation fail path)`, testName, error: detectionError.message, stack: detectionError.stack });
             }
@@ -798,6 +894,11 @@ export class PlaywrightService {
               default:
                 throw new Error(`Unsupported action ID: ${actionId}`);
             }
+            // Let the UI settle before capturing: a click often dismisses a menu and opens a
+            // dialog with an animation, and may fire XHRs. Without this the screenshot catches a
+            // mid-transition frame (old menu overlapping a half-open dialog).
+            await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
+            await page.waitForTimeout(600);
             resolvedLogger.verbose({ message: `PS:executeAdhocSequence - Taking screenshot for step`, testName, actionName, actionId });
             const screenshotBuffer = await page.screenshot({ type: 'png' });
             stepScreenshot = `data:image/png;base64,${screenshotBuffer.toString('base64')}`;
@@ -835,12 +936,7 @@ export class PlaywrightService {
       if (page && !page.isClosed()) {
         resolvedLogger.debug({ message: "PS:executeAdhocSequence - Attempting final element detection (success path)", testName, pageClosed: page?.isClosed() });
         try {
-          finalDetectedElements = await page.evaluate(() => { // Code for element detection (omitted for brevity, same as original)
-            const interactiveSelectors = ['input:not([type="hidden"])', 'button', 'a[href]', 'select', 'textarea', '[onclick]', '[role="button"]', '[tabindex]:not([tabindex="-1"])', 'h1, h2, h3, h4, h5, h6', 'img[alt]', 'form', '[data-testid]', '[data-test]'];
-            const detectedElementsEval: any[] = []; let globalElementCounter = 0;
-            interactiveSelectors.forEach(selector => { document.querySelectorAll(selector).forEach((element, index) => { const rect = element.getBoundingClientRect(); if (rect.width > 0 && rect.height > 0 && rect.top >= 0) { const tagName = element.tagName.toLowerCase(); const text = element.textContent?.trim() || ''; const placeholder = element.getAttribute('placeholder') || ''; const displayText = text || placeholder || element.getAttribute('alt') || `${tagName}-${index}`; let uniqueSelector = selector; if (element.id) { uniqueSelector = `#${element.id}`; } else if (element.className && typeof element.className === 'string') { const classes = element.className.split(' ').filter(c => c.length > 0 && !c.includes(':') && !c.includes('(') && !c.includes(')')); if (classes.length > 0) uniqueSelector = `${tagName}.${classes[0]}`; } let elementType = 'element'; if (tagName === 'input') elementType = element.getAttribute('type') || 'input'; else if (tagName === 'button' || element.getAttribute('role') === 'button') elementType = 'button'; else if (tagName === 'a') elementType = 'link'; else if (tagName.match(/h[1-6]/)) elementType = 'heading'; else if (tagName === 'select') elementType = 'select'; else if (tagName === 'textarea') elementType = 'textarea'; const attributes: Record<string, string> = {}; Array.from(element.attributes).forEach((attr: any) => { attributes[attr.name] = attr.value; }); detectedElementsEval.push({ id: `elem-${tagName}-${globalElementCounter++}`, type: elementType, selector: uniqueSelector, text: displayText.substring(0, 100), tag: tagName, attributes, boundingBox: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) } }); } }); });
-            return detectedElementsEval.slice(0, 50);
-          });
+          finalDetectedElements = await this.detectElementsOnPage(page);
         } catch (detectionError: any) {
           resolvedLogger.warn({ message: `PS:executeAdhocSequence - Error during final element detection (success path)`, testName, error: detectionError.message, stack: detectionError.stack });
         }
@@ -854,12 +950,7 @@ export class PlaywrightService {
       if (page && !page.isClosed()) {
         resolvedLogger.debug({ message: "PS:executeAdhocSequence - Attempting element detection after critical error", testName, pageClosed: page?.isClosed() });
         try {
-          finalDetectedElementsCriticalError = await page.evaluate(() => { // Code for element detection (omitted for brevity, same as original)
-            const interactiveSelectors = ['input:not([type="hidden"])', 'button', 'a[href]', 'select', 'textarea', '[onclick]', '[role="button"]', '[tabindex]:not([tabindex="-1"])', 'h1, h2, h3, h4, h5, h6', 'img[alt]', 'form', '[data-testid]', '[data-test]'];
-            const detectedElementsEval: any[] = []; let globalElementCounter = 0;
-            interactiveSelectors.forEach(selector => { document.querySelectorAll(selector).forEach((element, index) => { const rect = element.getBoundingClientRect(); if (rect.width > 0 && rect.height > 0 && rect.top >= 0) { const tagName = element.tagName.toLowerCase(); const text = element.textContent?.trim() || ''; const placeholder = element.getAttribute('placeholder') || ''; const displayText = text || placeholder || element.getAttribute('alt') || `${tagName}-${index}`; let uniqueSelector = selector; if (element.id) { uniqueSelector = `#${element.id}`; } else if (element.className && typeof element.className === 'string') { const classes = element.className.split(' ').filter(c => c.length > 0 && !c.includes(':') && !c.includes('(') && !c.includes(')')); if (classes.length > 0) uniqueSelector = `${tagName}.${classes[0]}`; } let elementType = 'element'; if (tagName === 'input') elementType = element.getAttribute('type') || 'input'; else if (tagName === 'button' || element.getAttribute('role') === 'button') elementType = 'button'; else if (tagName === 'a') elementType = 'link'; else if (tagName.match(/h[1-6]/)) elementType = 'heading'; else if (tagName === 'select') elementType = 'select'; else if (tagName === 'textarea') elementType = 'textarea'; const attributes: Record<string, string> = {}; Array.from(element.attributes).forEach((attr: any) => { attributes[attr.name] = attr.value; }); detectedElementsEval.push({ id: `elem-${tagName}-${globalElementCounter++}`, type: elementType, selector: uniqueSelector, text: displayText.substring(0, 100), tag: tagName, attributes, boundingBox: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) } }); } }); });
-            return detectedElementsEval.slice(0, 50);
-          });
+          finalDetectedElementsCriticalError = await this.detectElementsOnPage(page);
         } catch (detectionError: any) {
           resolvedLogger.warn({ message: `PS:executeAdhocSequence - Error during element detection (critical error path)`, testName, error: detectionError.message, stack: detectionError.stack });
         }
@@ -923,18 +1014,19 @@ export class PlaywrightService {
       resolvedLogger.debug({ message: `PS:detectElements - Navigating to URL`, url: targetUrl, pageClosed: page?.isClosed() });
       await page.goto(targetUrl, { waitUntil: 'domcontentloaded' });
 
+      // SPA content (Angular/DevExpress, React, …) mounts after domcontentloaded. Wait
+      // for the network to settle so the DOM is populated before we query it; fall back
+      // to the fixed wait if it never idles (long-polling/websockets).
+      await page.waitForLoadState('networkidle', { timeout: pageTimeout }).catch(() => {
+        resolvedLogger.debug({ message: "PS:detectElements - networkidle not reached, proceeding after fixed wait", url });
+      });
       const waitTime = userSettings?.playwrightWaitTime || DEFAULT_WAIT_TIME;
       resolvedLogger.debug({ message: `PS:detectElements - Waiting for timeout`, waitTime, pageClosed: page?.isClosed() });
       await page.waitForTimeout(waitTime);
 
-      let elements: any[] = [];
+      let elements: DetectedElement[] = [];
       try {
-        elements = await page.evaluate(() => { // Code for element detection (omitted for brevity, same as original)
-          const interactiveSelectors = ['input:not([type="hidden"])', 'button', 'a[href]', 'select', 'textarea', '[onclick]', '[role="button"]', '[tabindex]:not([tabindex="-1"])', 'h1, h2, h3, h4, h5, h6', 'img[alt]', 'form', '[data-testid]', '[data-test]'];
-          const detectedElements: any[] = []; let globalElementCounter = 0;
-          interactiveSelectors.forEach(selector => { document.querySelectorAll(selector).forEach((element, index) => { const rect = element.getBoundingClientRect(); if (rect.width > 0 && rect.height > 0 && rect.top >= 0) { const tagName = element.tagName.toLowerCase(); const text = element.textContent?.trim() || ''; const placeholder = element.getAttribute('placeholder') || ''; const displayText = text || placeholder || element.getAttribute('alt') || `${tagName}-${index}`; let uniqueSelector = selector; if (element.id) { uniqueSelector = `#${element.id}`; } else if (element.className && typeof element.className === 'string') { const classes = element.className.split(' ').filter(c => c.length > 0 && !c.includes(':') && !c.includes('(') && !c.includes(')')); if (classes.length > 0) { uniqueSelector = `${tagName}.${classes[0]}`; } } let elementType = 'element'; if (tagName === 'input') elementType = element.getAttribute('type') || 'input'; else if (tagName === 'button' || element.getAttribute('role') === 'button') elementType = 'button'; else if (tagName === 'a') elementType = 'link'; else if (tagName.match(/h[1-6]/)) elementType = 'heading'; else if (tagName === 'select') elementType = 'select'; else if (tagName === 'textarea') elementType = 'textarea'; const attributes: Record<string, string> = {}; Array.from(element.attributes).forEach((attr: any) => { attributes[attr.name] = attr.value; }); detectedElements.push({ id: `elem-${tagName}-${globalElementCounter++}`, type: elementType, selector: uniqueSelector, text: displayText.substring(0, 100), tag: tagName, attributes, boundingBox: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) } }); } }); });
-          return detectedElements.slice(0, 50);
-        });
+        elements = await this.detectElementsOnPage(page);
       } catch (evalError: any) {
         resolvedLogger.warn({ message: "PS:detectElements - Evaluation failed", error: evalError.message });
       }

--- a/server/routes/tests.routes.ts
+++ b/server/routes/tests.routes.ts
@@ -58,23 +58,11 @@ router.post("/api/tests/:id/run", async (req, res) => {
     }
 });
 
-// POST /api/detect-elements - Inspector
-router.post("/api/detect-elements", async (req, res) => {
-    // Basic wrapper for element detection
-    const { url } = req.body;
-    if(!url) return res.status(400).json({ error: "URL required" });
-    
-    try {
-        // Assuming loadWebsite returns elements (it currently returns screenshot/html, 
-        // usually the client parses it or we need a service method for detection).
-        // Reuse loadWebsite for now as in original routes.
-        const result = await playwrightService.loadWebsite(url);
-        if(result.success) res.json(result);
-        else res.status(500).json({ error: result.error });
-    } catch(e: any) {
-        res.status(500).json({ error: e.message });
-    }
-});
+// NOTE: /api/detect-elements is intentionally NOT defined here. It is handled by the
+// authenticated handler in routes.ts, which calls playwrightService.detectElements()
+// (with the user's settings) and returns { success, elements }. An earlier stub here
+// wrongly called loadWebsite() and returned no `elements`, shadowing the real route
+// and leaving the Detected Elements panel empty.
 
 
 // --- API Tests ---


### PR DESCRIPTION
The Create Test flow was broken end-to-end against the DMO Angular/DevExpress app. Fixes, in the order a user hits them:

- Blank preview/screenshot: loadWebsite/detectElements waited only for domcontentloaded + 1s, capturing an empty SPA shell. Now wait for networkidle (with fallback) and a longer settle.
- Empty "Detected Elements": a stub /api/detect-elements in tests.routes.ts shadowed the real handler and returned no `elements`. Removed it.
- Dragged element vanished: the TestNode had no drop target. Added a react-dnd useDrop that binds the detected element as the step's target.
- Test executed itself mid-edit: completing a step auto-triggered a debounced run. Removed; tests run only via the Execute Test button.
- Wrong element bound (dropped "Application Info", got "Change User"): useDrag lacked a deps array, so it kept the stale item after a re-detect (element ids are positional). Added [element].
- Execution clicked the wrong/no element: detection produced non-unique selectors (button.mat-mdc-menu-item shared by all menu items). Detection now builds guaranteed-unique selectors (id -> stable attr -> non-transient class combo -> :nth-of-type path) and dedups elements. Consolidated the four duplicated detection blocks into one shared detectElementsOnPage(page) so they can no longer drift; the shared version includes a __name shim required because tsx/esbuild keepNames wraps named helpers that don't exist in-page.
- Screenshot caught a mid-transition frame (old menu overlapping half-open dialog): added a networkidle + 600ms settle before the per-step screenshot.